### PR TITLE
broadcast register & measure_reset!

### DIFF
--- a/src/Blocks/Measure.jl
+++ b/src/Blocks/Measure.jl
@@ -12,16 +12,54 @@ abstract type AbstractMeasure <: AbstractBlock end
 #####################
 abstract type AbstractMeasure <: AbstractBlock end
 
+"""
+    Measure <: AbstractMeasure
+    Measure() -> Measure
+
+Measure block, collapse a state and store measured value, e.g.
+
+# Examples
+```julia-repl
+julia> m = Measure();
+
+julia> reg = product_state(4, 7)
+DefaultRegister{1, Complex{Float64}}
+    active qubits: 4/4
+
+julia> reg |> m
+DefaultRegister{1, Complex{Float64}}
+    active qubits: 4/4
+
+julia> m.result
+1-element Array{Int64,1}:
+ 7
+```
+
+Note:
+`Measure` returns a vector here, the length corresponds to batch dimension of registers.
+"""
 mutable struct Measure <: AbstractMeasure
     result::Vector{Int}
     Measure() = new()
 end
 
+"""
+    MeasureAndRemove <: AbstractMeasure
+    MeasureAndRemove() -> MeasureAndRemove
+
+Measure and remove block, remove measured qubits and store measured value.
+"""
 mutable struct MeasureAndRemove <: AbstractMeasure
     result::Vector{Int}
     MeasureAndRemove() = new()
 end
 
+"""
+    MeasureAndReset <: AbstractMeasure
+    MeasureAndReset([val=0]) -> MeasureAndReset
+
+Measure and reset block, reset measured qubits to `val` and store measured value.
+"""
 mutable struct MeasureAndReset <: AbstractMeasure
     val::Int
     result::Vector{Int}
@@ -36,7 +74,8 @@ for (BT, FUNC) in zip((:Measure, :MeasureAndRemove, :MeasureAndReset), (:measure
         block.result = samples
         reg
     end
+    EXTRA = BT == :MeasureAndReset ? :(" -> $(pb.val)") : :("")
     @eval function print_block(io::IO, pb::$BT)
-        printstyled(io, "$BT"; bold=true, color=:red)
+        printstyled(io, string($BT)*$EXTRA; bold=true, color=:red)
     end
 end

--- a/src/Blocks/Measure.jl
+++ b/src/Blocks/Measure.jl
@@ -1,4 +1,4 @@
-export AbstractMeasure, Measure, MeasureAndRemove
+export AbstractMeasure, Measure, MeasureAndRemove, MeasureAndReset
 
 """
     AbstractMeasure <: AbstractBlock
@@ -17,27 +17,26 @@ mutable struct Measure <: AbstractMeasure
     Measure() = new()
 end
 
-function apply!(reg::AbstractRegister, block::Measure)
-    samples = measure!(reg)
-    block.result = samples
-    reg
-end
-
 mutable struct MeasureAndRemove <: AbstractMeasure
     result::Vector{Int}
     MeasureAndRemove() = new()
 end
 
-function apply!(reg::AbstractRegister, block::MeasureAndRemove)
-    samples = measure_remove!(reg)
-    block.result = samples
-    reg
+mutable struct MeasureAndReset <: AbstractMeasure
+    val::Int
+    result::Vector{Int}
+    MeasureAndReset(val::Int) = new(val)
 end
+MeasureAndReset() = MeasureAndReset(0)
 
-function print_block(io::IO, pb::MeasureAndRemove)
-    printstyled(io, "measure & remove"; bold=true, color=:red)
-end
-
-function print_block(io::IO, pb::Measure)
-    printstyled(io, "measure"; bold=true, color=:red)
+for (BT, FUNC) in zip((:Measure, :MeasureAndRemove, :MeasureAndReset), (:measure!, :measure_remove!, :measure_reset!))
+    APPLY_ON_REG = BT == :MeasureAndReset ? :($FUNC(reg, val=block.val)) : :($FUNC(reg))
+    @eval function apply!(reg::AbstractRegister, block::$BT)
+        samples = $APPLY_ON_REG
+        block.result = samples
+        reg
+    end
+    @eval function print_block(io::IO, pb::$BT)
+        printstyled(io, "$BT"; bold=true, color=:red)
+    end
 end

--- a/src/Interfaces/Measure.jl
+++ b/src/Interfaces/Measure.jl
@@ -1,6 +1,5 @@
-import ..Blocks: measure
-
-export MEASURE, MEASURE_REMOVE
+export MEASURE, MEASURE_REMOVE, MEASURE_RESET
 
 const MEASURE = Measure()
 const MEASURE_REMOVE = MeasureAndRemove()
+const MEASURE_RESET = MeasureAndReset()

--- a/src/Interfaces/Measure.jl
+++ b/src/Interfaces/Measure.jl
@@ -1,4 +1,5 @@
-export MEASURE, MEASURE_REMOVE, MEASURE_RESET
+import ..Blocks: Measure, MeasureAndReset, MeasureAndRemove
+export MEASURE, MEASURE_REMOVE, MEASURE_RESET, Measure, MeasureAndReset, MeasureAndRemove
 
 const MEASURE = Measure()
 const MEASURE_REMOVE = MeasureAndRemove()

--- a/src/Registers/Default.jl
+++ b/src/Registers/Default.jl
@@ -59,26 +59,26 @@ stack(regs::DefaultRegister...) = DefaultRegister{sum(nbatch, regs)}(hcat((reg.s
 Base.repeat(reg::DefaultRegister{B}, n::Int) where B = DefaultRegister{B*n}(hcat((reg.state for i=1:n)...,))
 
 """
-    product_state(::Type{T}, n::Int, config::Int, nbatch::Int=1) -> DefaultRegister
+    product_state([::Type{T}], n::Int, config::Int, nbatch::Int=1) -> DefaultRegister
 
 a product state on given configuration `config`, e.g. product_state(ComplexF64, 5, 0) will give a zero state on a 5 qubit register.
 """
 product_state(::Type{T}, n::Int, config::Integer, nbatch::Int=1) where T = register((arr=zeros(T, 1<<n, nbatch); arr[config+1,:] .= 1; arr))
 
 """
-    zero_state(::Type{T}, n::Int, nbatch::Int=1) -> DefaultRegister
+    zero_state([::Type{T}], n::Int, nbatch::Int=1) -> DefaultRegister
 """
 zero_state(::Type{T}, n::Int, nbatch::Int=1) where T = product_state(T, n, 0, nbatch)
 
 """
-    rand_state(::Type{T}, n::Int, nbatch::Int=1) -> DefaultRegister
+    rand_state([::Type{T}], n::Int, nbatch::Int=1) -> DefaultRegister
 
 here, random complex numbers are generated using `randn(ComplexF64)`.
 """
 rand_state(::Type{T}, n::Int, nbatch::Int=1) where T = register(randn(T, 1<<n, nbatch) + im*randn(T, 1<<n, nbatch)) |> normalize!
 
 """
-    uniform_state(::Type{T}, n::Int, nbatch::Int=1) -> DefaultRegister
+    uniform_state([::Type{T}], n::Int, nbatch::Int=1) -> DefaultRegister
 
 uniform state, the state after applying H gates on |0> state.
 """

--- a/src/Registers/Registers.jl
+++ b/src/Registers/Registers.jl
@@ -5,8 +5,8 @@ using StatsBase
 using MacroTools: @forward
 using ..Intrinsics
 
-import Base: length
-import Base: eltype, copy, similar, *, join
+import Base: length, broadcastable
+import Base: eltype, copy, similar, *, join, copyto!
 import Base: show
 
 # import package APIs

--- a/test/Blocks/Measure.jl
+++ b/test/Blocks/Measure.jl
@@ -60,3 +60,12 @@ end
     @test nactive(reg2) == 0
     @test reg2 |> isnormalized
 end
+
+@testset "measure and reset" begin
+    reg = rand_state(4)
+    mb = MeasureAndReset(3)
+    reg |> mb
+    @test all(measure(reg, 10) .== 3)
+    @test length(mb.result) == 1
+end
+

--- a/test/Interfaces/Interfaces.jl
+++ b/test/Interfaces/Interfaces.jl
@@ -97,6 +97,7 @@ end
 @testset "measure" begin
     @test MEASURE isa Measure
     @test MEASURE_REMOVE isa MeasureAndRemove
+    @test MEASURE_RESET isa MeasureAndReset
 end
 
 @testset "concentrate" begin

--- a/test/Registers/Default.jl
+++ b/test/Registers/Default.jl
@@ -35,6 +35,12 @@ using Yao.Intrinsics
     creg = copy(reg)
     @test state(creg) == state(reg)
     @test state(creg) !== state(reg)
+
+    reg = rand_state(5,3)
+    reg2 = similar(reg)
+    @test !(reg2 ≈ reg)
+    copyto!(reg2, reg)
+    @test reg2 == reg
 end
 
 @testset "Constructors B=1" begin
@@ -112,4 +118,20 @@ end
     @test r1'*r1 ≈ [1 1; 1 1]
     @test r1 ≈ r2
     @test r3 ≈ r2
+end
+
+@testset "broadcast register" begin
+    reg = rand_state(5,3)
+    c = put(5, 2=>X)
+    ra = copy(reg)
+    rb = copy(reg)
+    @test all(ra .|> Ref(c) .≈ rb .|> Ref(c))
+    @test typeof.(reg)[1] <: DefaultRegister{<:Any, <:Any, <:SubArray}
+end
+
+@testset "measure and reset" begin
+    reg = rand_state(4)
+    res = measure_reset!(reg, (4,))
+    result = measure(reg, 10)
+    @test all(result .< 8)
 end


### PR DESCRIPTION
This PR brings two changes

### 1. Make register broadcastable
e.g. 
```julia
julia> rs = rand_state(4,3)
DefaultRegister{3, Complex{Float64}}
    active qubits: 4/4

julia> rs .|> Ref(put(4, 1=>X))
(DefaultRegister{1, Complex{Float64}}
    active qubits: 4/4, DefaultRegister{1, Complex{Float64}}
    active qubits: 4/4, DefaultRegister{1, Complex{Float64}}
    active qubits: 4/4)
```

### 2. New Measure and Reset function
Which can be useful in implementing some algorithms require reuable qubits, like the one in
> Towards Quantum Machine Learning with Tensor Networks
> William Huggins, Piyush Patel, K. Birgitta Whaley, E. Miles Stoudenmire
> https://arxiv.org/abs/1803.11537

usage:
```julia
reg = rand_state(4)
mb = MeasureAndReset(3)
reg |> mb
@test all(measure(reg, 10) .== 3)
```