### PR TITLE
fix warning & rm wrong depwarn

### DIFF
--- a/lib/YaoBase/src/abstract_register.jl
+++ b/lib/YaoBase/src/abstract_register.jl
@@ -5,9 +5,9 @@ export @λ, @lambda
 addbits!(n::Int) = @λ(register -> addbits!(register, n))
 insert_qudits!(loc::Int; nqudits::Int = 1) =
     @λ(register -> insert_qudits!(register, loc; nqudits = nqudits))
-insert_qubits!(loc::Int; nqubits::Int = 1) =
+YaoAPI.insert_qubits!(loc::Int; nqubits::Int = 1) =
     @λ(register -> insert_qubits!(register, loc; nqubits = nqubits))
-insert_qubits!(reg::AbstractRegister{2}, loc::Int; nqubits::Int = 1) = insert_qudits!(reg, loc; nqudits=nqubits)
+YaoAPI.insert_qubits!(reg::AbstractRegister{2}, loc::Int; nqubits::Int = 1) = insert_qudits!(reg, loc; nqudits=nqubits)
 
 nremain(r::AbstractRegister) = nqudits(r) - nactive(r)
 nlevel(r::AbstractRegister{D}) where {D} = D

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -1,3 +1,2 @@
-import YaoArrayRegister: insert_qudits!, ArrayReg
-@deprecate insert_qubits!(args...; kwargs...) insert_qudits!(args...; kwargs...)
+import YaoArrayRegister: ArrayReg
 @deprecate ArrayReg(bitstr::BitStr; nbatch::Union{Int,NoBatch}=NoBatch())  arrayreg(ComplexF64, bitstr; nbatch=nbatch)


### PR DESCRIPTION
let's not deprecate the qubits interfaces, they are not identical to the qudits. It's still necessary to have them. I think it's important to let users who only wants to deal with qubits to stay in qubits land

Also @GiggleLiu let's not use so much `import`s and actually try not to use `import` at all in the future, it's very painful when you try to find if a method is overloaded or created as new function for issues like this. 