### PR TITLE
Enforce `Matrix{Basic}` type during conversion

### DIFF
--- a/lib/YaoSym/src/symengine/register.jl
+++ b/lib/YaoSym/src/symengine/register.jl
@@ -22,7 +22,7 @@ function SymReg(r::AbstractArrayReg{D,<:Number}) where {D}
     return arrayreg(SparseMatrixCSC(smat); nbatch=nbatch(r), nlevel=D)
 end
 
-_pretty_basic(x) = x
+_pretty_basic(x) = Basic(x)
 _pretty_basic(x::Real) = isinteger(x) ? Basic(Int(x)) : Basic(x)
 function _pretty_basic(x::Complex)
     if isreal(x)

--- a/lib/YaoSym/src/symengine/register.jl
+++ b/lib/YaoSym/src/symengine/register.jl
@@ -23,7 +23,7 @@ function SymReg(r::AbstractArrayReg{D,<:Number}) where {D}
 end
 
 _pretty_basic(x) = x
-_pretty_basic(x::Real) = isinteger(x) ? Int(x) : x
+_pretty_basic(x::Real) = isinteger(x) ? Basic(Int(x)) : Basic(x)
 function _pretty_basic(x::Complex)
     if isreal(x)
         return _pretty_basic(real(x))

--- a/lib/YaoSym/test/symengine/blocks.jl
+++ b/lib/YaoSym/test/symengine/blocks.jl
@@ -20,8 +20,10 @@ end
 
 @testset "mat" begin
     @vars θ γ η
-    for G in [X, Y, Z, ConstGate.T, H, ConstGate.Tdag, ConstGate.T, I2, (0.5+0.5im)*X]
-        @test Matrix(mat(Basic, G)) ≈ Matrix(mat(G))
+    for G in [X, Y, Z, ConstGate.T, H, ConstGate.S, ConstGate.Sdag, ConstGate.Tdag, ConstGate.T, I2, (0.5+0.5im)*X]
+        B = mat(Basic, G)
+        @test eltype(B) === Basic
+        @test Matrix(B) ≈ Matrix(mat(G))
         @test Matrix(mat(Basic, control(4, 3, 2 => G))) ≈ Matrix(control(4, 3, 2 => G))
     end
 


### PR DESCRIPTION
The `_pretty_basic` call mixes original element matrix type. By default `S` gate matrix is
```julia
julia> mat(S)
2×2 LinearAlgebra.Diagonal{ComplexF64, Vector{ComplexF64}}:
 1.0+0.0im      ⋅    
     ⋅      0.0+1.0im

```
but `mat(Bacis, S)` returns `Number`-typed matrix 
```julia
julia> mat(Bacis, S)
2×2 Matrix{Number}:
 1   0
 0  im
```
This makes impossible to use matrix multiplication.
```julia
julia> q
2×1 SparseArrays.SparseMatrixCSC{Basic, Int64} with 2 stored entries:
 (1/2)*sqrt(2)
 (1/2)*sqrt(2)

julia> mat(Bacis, S) * q.state
MethodError: no method matching zero(::Type{Any})
Closest candidates are:
  zero(::Type{Union{Missing, T}}) where T at ~/Applications/julia-1.7.2/share/julia/base/missing.jl:105
  zero(::Union{Type{P}, P}) where P<:Dates.Period at ~/Applications/julia-1.7.2/share/julia/stdlib/v1.7/Dates/src/periods.jl:53
  zero(::BitBasis.BitStr{N, T}) where {N, T} at ~/.julia/packages/BitBasis/8Z70U/src/bit_str.jl:51
  ...

Stacktrace:
 [1] zero(#unused#::Type{Any})
   @ Base ./missing.jl:106
 [2] mul!(C::Matrix{Any}, X::Matrix{Number}, A::SparseArrays.SparseMatrixCSC{Basic, Int64}, α::Bool, β::Bool)
   @ SparseArrays ~/Applications/julia-1.7.2/share/julia/stdlib/v1.7/SparseArrays/src/linalg.jl:95
 [3] *(X::Matrix{Number}, A::SparseArrays.SparseMatrixCSC{Basic, Int64})
   @ SparseArrays ~/Applications/julia-1.7.2/share/julia/stdlib/v1.7/SparseArrays/src/linalg.jl:115
 [4] top-level scope
   @ In[24]:1
 [5] eval
```

This PR correct type of the matrix
```julia
julia> mat(Basic, S)
2×2 Matrix{Basic}:
 1   0
 0  im

julia> mat(Basic, S)*q.state
2×1 Matrix{Basic}:
  (1/2)*sqrt(2)
 1/2*im*sqrt(2)
```
