### PR TITLE
Qudits instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.jl.*.cov
 *.jl.mem
 _*.yao
+_local/
 
 docs/build/
 docs/site/

--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ YaoBlocks = "418bc28f-b43b-5e0b-a6e7-61bbc1a2c1df"
 YaoSym = "3b27209a-d3d6-11e9-3c0f-41eb92b2cb9d"
 
 [compat]
-BitBasis = "0.7"
+BitBasis = "0.8"
 Reexport = "1"
 YaoAPI = "0.4"
 YaoArrayRegister = "0.8"

--- a/lib/YaoAPI/src/blocks.jl
+++ b/lib/YaoAPI/src/blocks.jl
@@ -195,7 +195,7 @@ ArrayReg{2, ComplexF64, Array...}
     nlevel: 2
 
 julia> measure(r;nshots=10)
-10-element Vector{BitBasis.BitStr64{2}}:
+10-element Vector{DitStr{2, 2, Int64}}:
  01 ₍₂₎
  01 ₍₂₎
  01 ₍₂₎
@@ -304,7 +304,7 @@ julia> mat(kron(X, X))
  1.0+0.0im  0.0+0.0im  0.0+0.0im  0.0+0.0im
 
 julia> mat(kron(X, X) + put(2, 1=>X))
-4×4 SparseArrays.SparseMatrixCSC{ComplexF64, Int64} with 8 stored entries:
+4×4 SparseMatrixCSC{ComplexF64, Int64} with 8 stored entries:
      ⋅      1.0+0.0im      ⋅      1.0+0.0im
  1.0+0.0im      ⋅      1.0+0.0im      ⋅
      ⋅      1.0+0.0im      ⋅      1.0+0.0im

--- a/lib/YaoAPI/src/registers.jl
+++ b/lib/YaoAPI/src/registers.jl
@@ -103,7 +103,7 @@ julia> reg = zero_state(5; nbatch=2);
 julia> apply!(viewbatch(reg, 2), put(5, 2=>X));
 
 julia> measure(reg; nshots=3)
-3×2 Matrix{BitBasis.BitStr64{5}}:
+3×2 Matrix{DitStr{2, 5, Int64}}:
  00000 ₍₂₎  00010 ₍₂₎
  00000 ₍₂₎  00010 ₍₂₎
  00000 ₍₂₎  00010 ₍₂₎
@@ -135,7 +135,7 @@ ArrayReg{2, ComplexF64, Array...}
     nlevel: 2
 
 julia> measure(reg; nshots=3)
-3-element Vector{BitBasis.BitStr64{7}}:
+3-element Vector{DitStr{2, 7, Int64}}:
  0001101 ₍₂₎
  0001101 ₍₂₎
  0001101 ₍₂₎
@@ -175,7 +175,7 @@ ArrayReg{2, ComplexF64, Array...}
     nlevel: 2
 
 julia> measure(reg; nshots=3)
-3-element Vector{BitBasis.BitStr64{7}}:
+3-element Vector{DitStr{2, 7, Int64}}:
  0110001 ₍₂₎
  0110001 ₍₂₎
  0110001 ₍₂₎
@@ -213,13 +213,13 @@ ArrayReg{2, ComplexF64, Array...}
     nlevel: 2
 
 julia> measure(reg; nshots=3)
-3-element Vector{BitBasis.BitStr64{3}}:
+3-element Vector{DitStr{2, 3, Int64}}:
  111 ₍₂₎
  111 ₍₂₎
  111 ₍₂₎
 
 julia> measure(apply(reg, put(3, 2=>X)); nshots=3)
-3-element Vector{BitBasis.BitStr64{3}}:
+3-element Vector{DitStr{2, 3, Int64}}:
  101 ₍₂₎
  101 ₍₂₎
  101 ₍₂₎
@@ -309,7 +309,7 @@ julia> reg = product_state(bit"010101");
 julia> reorder!(reg, (1,4,2,5,3,6));
 
 julia> measure(reg)
-1-element Vector{BitBasis.BitStr64{6}}:
+1-element Vector{DitStr{2, 6, Int64}}:
  000111 ₍₂₎
 ```
 """
@@ -329,7 +329,7 @@ ArrayReg{2, ComplexF64, Array...}
     nlevel: 2
 
 julia> measure(invorder!(reg); nshots=3)
-3-element Vector{BitBasis.BitStr64{6}}:
+3-element Vector{DitStr{2, 6, Int64}}:
  101010 ₍₂₎
  101010 ₍₂₎
  101010 ₍₂₎
@@ -350,7 +350,7 @@ The following code collapse a random state to a certain state.
 
 ```jldoctest; setup=:(using Yao)
 julia> measure(collapseto!(rand_state(3), bit"001"); nshots=3)
-3-element Vector{BitBasis.BitStr64{3}}:
+3-element Vector{DitStr{2, 3, Int64}}:
  001 ₍₂₎
  001 ₍₂₎
  001 ₍₂₎
@@ -398,13 +398,13 @@ ArrayReg{2, ComplexF64, Array...}
     nlevel: 2
 
 julia> measure(reg; nshots=3)
-3-element Vector{BitBasis.BitStr64{3}}:
+3-element Vector{DitStr{2, 3, Int64}}:
  110 ₍₂₎
  110 ₍₂₎
  110 ₍₂₎
 
 julia> measure(reg, (2,3); nshots=3)
-3-element Vector{BitBasis.BitStr64{2}}:
+3-element Vector{DitStr{2, 2, Int64}}:
  11 ₍₂₎
  11 ₍₂₎
  11 ₍₂₎
@@ -452,7 +452,7 @@ julia> measure!(ResetTo(bit"011"), reg)
 110 ₍₂₎
 
 julia> measure(reg; nshots=3)
-3-element Vector{BitBasis.BitStr64{3}}:
+3-element Vector{DitStr{2, 3, Int64}}:
  011 ₍₂₎
  011 ₍₂₎
  011 ₍₂₎

--- a/lib/YaoArrayRegister/Project.toml
+++ b/lib/YaoArrayRegister/Project.toml
@@ -18,7 +18,7 @@ YaoAPI = "0843a435-28de-4971-9e8b-a9641b2983a8"
 
 [compat]
 Adapt = "3"
-BitBasis = "0.7"
+BitBasis = "0.8"
 LegibleLambdas = "0.3"
 LuxurySparse = "0.6"
 MLStyle = "0.4"

--- a/lib/YaoArrayRegister/src/YaoArrayRegister.jl
+++ b/lib/YaoArrayRegister/src/YaoArrayRegister.jl
@@ -46,7 +46,7 @@ export AbstractArrayReg,
     exchange_sysenv
 
 # BitBasis
-export @bit_str, hypercubic
+export @bit_str, @dit_str, BitStr, DitStr, hypercubic
 
 # YaoAPI
 export AbstractRegister,
@@ -74,6 +74,7 @@ export AbstractRegister,
     insert_qubits!,
     most_probable,
     instruct!,
+    accum_instruct!,
     invorder!,
     measure,
     measure!,
@@ -106,6 +107,7 @@ include("operations.jl")
 include("focus.jl")
 
 include("instruct.jl")
+include("qudit_instruct.jl")
 
 include("density_matrix.jl")
 include("measure.jl")

--- a/lib/YaoArrayRegister/src/YaoArrayRegister.jl
+++ b/lib/YaoArrayRegister/src/YaoArrayRegister.jl
@@ -96,6 +96,9 @@ export AbstractRegister,
     basis,
     clone
 
+# matrix types
+export IMatrix, PermMatrix, Diagonal, SparseMatrixCSC
+
 # others
 export Const, logdi
 

--- a/lib/YaoArrayRegister/src/YaoArrayRegister.jl
+++ b/lib/YaoArrayRegister/src/YaoArrayRegister.jl
@@ -43,7 +43,8 @@ export AbstractArrayReg,
     regadd!,
     regsub!,
     regscale!,
-    exchange_sysenv
+    exchange_sysenv,
+    print_table
 
 # BitBasis
 export @bit_str, @dit_str, BitStr, DitStr, hypercubic

--- a/lib/YaoArrayRegister/src/instruct.jl
+++ b/lib/YaoArrayRegister/src/instruct.jl
@@ -8,12 +8,12 @@
 
 function YaoAPI.instruct!(r::BatchedArrayReg{D}, operator, locs::Tuple, args...) where {D}
     length(locs) == 0 && return r
-    instruct!(Val(D), r.state, _match_type(r.state, operator), args...)
+    instruct!(Val(D), r.state, _match_type(r.state, operator), locs, args...)
     return r
 end
 function YaoAPI.instruct!(r::ArrayReg{D}, operator, locs::Tuple, args...) where {D}
     length(locs) == 0 && return r
-    instruct!(Val(D), vec(r.state), _match_type(r.state, operator), args...)
+    instruct!(Val(D), vec(r.state), _match_type(r.state, operator), locs, args...)
     return r
 end
 _match_type(::AbstractVecOrMat{T1}, operator::Val) where {T1} = operator

--- a/lib/YaoArrayRegister/src/instruct.jl
+++ b/lib/YaoArrayRegister/src/instruct.jl
@@ -6,53 +6,21 @@
 #
 # In order to make multi threading work, the state vector MUST be named as state
 
-function YaoAPI.instruct!(
-    r::BatchedArrayReg{D},
-    op,
-    locs::Tuple,
-    control_locs::Tuple,
-    control_bits::Tuple,
-) where {D}
-    instruct!(Val(D), r.state, op, locs, control_locs, control_bits)
+function YaoAPI.instruct!(r::BatchedArrayReg{D}, operator, locs::Tuple, args...) where {D}
+    length(locs) == 0 && return r
+    instruct!(Val(D), r.state, _match_type(r.state, operator), args...)
     return r
 end
-
-function YaoAPI.instruct!(
-    r::ArrayReg{D},
-    op,
-    locs::Tuple,
-    control_locs::Tuple,
-    control_bits::Tuple,
-) where {D}
-    instruct!(Val(D), vec(r.state), op, locs, control_locs, control_bits)
+function YaoAPI.instruct!(r::ArrayReg{D}, operator, locs::Tuple, args...) where {D}
+    length(locs) == 0 && return r
+    instruct!(Val(D), vec(r.state), _match_type(r.state, operator), args...)
     return r
 end
-
-function YaoAPI.instruct!(r::BatchedArrayReg{D}, op, locs::Tuple) where {D}
-    instruct!(Val(D), r.state, op, locs)
-    return r
-end
-
-function YaoAPI.instruct!(r::ArrayReg{D}, op, locs::Tuple) where D
-    instruct!(Val(D), vec(r.state), op, locs)
-    return r
-end
-
-function YaoAPI.instruct!(
-    r::AbstractArrayReg{D},
-    op,
-    locs::Tuple,
-    control_locs::Tuple,
-    control_bits::Tuple,
-    theta::Number,
-) where {D}
-    instruct!(Val(D), r.state, op, locs, control_locs, control_bits, theta)
-    return r
-end
-
-function YaoAPI.instruct!(r::AbstractArrayReg{D}, op, locs::Tuple, theta::Number) where {D}
-    instruct!(Val(D), r.state, op, locs, theta)
-    return r
+_match_type(::AbstractVecOrMat{T1}, operator::Val) where {T1} = operator
+_match_type(::AbstractVecOrMat{T1}, operator::AbstractMatrix{T1}) where {T1} = operator
+function _match_type(::AbstractVecOrMat{T1}, operator::AbstractMatrix{T2}) where {T1,T2}
+    @warn "Element Type Mismatch: register $(T1), operator $(T2). Converting operator to match, this may cause performance issue"
+    return copyto!(similar(operator, T1), operator)
 end
 
 """
@@ -77,68 +45,27 @@ macro threads(ex)
     end)
 end
 
-# to avoid potential ambiguity, we limit them to tuple for now
-# but they only has to be an iterator over integers
-const Locations{T} = NTuple{N,T} where {N}
-const BitConfigs{T} = NTuple{N,T} where {N}
-
+# the most generic matrix interface.
 function YaoAPI.instruct!(::Val{2},
-    state::AbstractVecOrMat{T1},
-    operator::AbstractMatrix{T2},
+    state::AbstractVecOrMat{T},
+    operator::AbstractMatrix{T},
     locs::NTuple{M,Int},
-    control_locs::NTuple{C,Int} = (),
-    control_bits::NTuple{C,Int} = (),
-) where {T1,T2,M,C}
+    control_locs::NTuple{C,Int},
+    control_bits::NTuple{C,Int},
+) where {T,M,C}
+    # prepare instruct
+    N = log2dim1(state)
+    operator = sort_unitary(Val(2), operator, locs)  # make locs ordered
 
-    @warn "Element Type Mismatch: register $(T1), operator $(T2). Converting operator to match, this may cause performance issue"
-    return instruct!(Val(2),
-        state,
-        copyto!(similar(operator, T1), operator),
-        locs,
-        control_locs,
-        control_bits,
-    )
-end
-
-function _prepare_instruct(
-    state,
-    U,
-    locs::NTuple{M},
-    control_locs,
-    control_bits::NTuple{C},
-) where {M,C}
-    N, MM = log2dim1(state), size(U, 1)
-
+    # get itercontrol and locs_raw
     locked_bits = MVector(control_locs..., locs...)
     locked_vals = MVector(control_bits..., (0 for k = 1:M)...)
     locs_raw_it = (b + 1 for b in itercontrol(N, setdiff(1:N, locs), zeros(Int, N - M)))
     locs_raw = SVector(locs_raw_it...)
     ic = itercontrol(N, locked_bits, locked_vals)
-    return locs_raw, ic
-end
 
-function YaoAPI.instruct!(::Val{2},
-    state::AbstractVecOrMat{T},
-    operator::AbstractMatrix{T},
-    locs::Tuple{},
-    control_locs::NTuple{C,Int} = (),
-    control_bits::NTuple{C,Int} = (),
-) where {T,C}
-    return state
-end
-
-function YaoAPI.instruct!(::Val{2},
-    state::AbstractVecOrMat{T},
-    operator::AbstractMatrix{T},
-    locs::NTuple{M,Int},
-    control_locs::NTuple{C,Int} = (),
-    control_bits::NTuple{C,Int} = (),
-) where {T,M,C}
-    operator = sort_unitary(operator, locs)
-    locs_raw, ic = _prepare_instruct(state, operator, locs, control_locs, control_bits)
     return _instruct!(state, autostatic(operator), locs_raw, ic)
 end
-
 function _instruct!(
     state::AbstractVecOrMat{T},
     U::AbstractMatrix{T},
@@ -167,15 +94,22 @@ function _instruct!(
     end
     return state
 end
-
-YaoAPI.instruct!(::Val{2}, state::AbstractVecOrMat, U::IMatrix, locs::NTuple{N,Int}) where N = state
-YaoAPI.instruct!(::Val{2}, state::AbstractVecOrMat, U::IMatrix, locs::Tuple{Int}) = state
-
-function YaoAPI.instruct!(::Val{2},
+function YaoAPI.instruct!(::Val{2},  # fallback to controlled case
     state::AbstractVecOrMat{T},
-    U1::AbstractMatrix{T},
-    (loc,)::Tuple{Int},
-) where {T}
+    operator::AbstractMatrix{T},
+    locs::NTuple{M,Int}
+) where {T,M}
+    if M == 1
+        return single_qubit_instruct!(state, operator, locs[1])
+    end
+    instruct!(Val(2), state, operator, locs, (), ())
+end
+
+# specialize: IMatrix
+YaoAPI.instruct!(::Val{2}, state::AbstractVecOrMat, U::IMatrix, locs::NTuple{N,Int}) where N = state
+
+# specialize: single qubit generic matrix
+function single_qubit_instruct!(state::AbstractVecOrMat{T}, U1::AbstractMatrix{T}, loc::Int) where {T}
     a, c, b, d = U1
     instruct_kernel(state, loc, 1 << (loc - 1), 1 << loc, a, b, c, d)
     return state
@@ -190,13 +124,12 @@ end
     return state
 end
 
-function YaoAPI.instruct!(::Val{2},
-    state::AbstractVecOrMat{T},
-    U1::SDPermMatrix{T},
-    (loc,)::Tuple{Int},
-) where {T}
+# specialize: single qubit IMatrix
+single_qubit_instruct!(state::AbstractVecOrMat, U::IMatrix, loc::Int) = state
+
+# specialize: single qubit permutation matrix
+function single_qubit_instruct!(state::AbstractVecOrMat{T}, U1::SDPermMatrix{T}, loc::Int) where {T}
     U1.perm[1] == 1 && return instruct!(Val(2),state, Diagonal(U1), (loc,))
-    mask = bmask(loc)
     b, c = U1.vals
     step = 1 << (loc - 1)
     step_2 = 1 << loc
@@ -209,12 +142,8 @@ function YaoAPI.instruct!(::Val{2},
     return state
 end
 
-function YaoAPI.instruct!(::Val{2},
-    state::AbstractVecOrMat{T},
-    U1::SDDiagonal{T},
-    (loc,)::Tuple{Int},
-) where {T}
-    mask = bmask(loc)
+# specialize: single qubit diagonal matrix
+function single_qubit_instruct!(state::AbstractVecOrMat{T}, U1::SDDiagonal{T}, loc::Int) where {T}
     a, d = U1.diag
     step = 1 << (loc - 1)
     step_2 = 1 << loc
@@ -227,7 +156,7 @@ function YaoAPI.instruct!(::Val{2},
     return state
 end
 
-# specialization
+# specialize: named gates
 # paulis
 function YaoAPI.instruct!(::Val{2},
     state::AbstractVecOrMat,
@@ -253,7 +182,6 @@ function YaoAPI.instruct!(::Val{2},
 ) where {N}
     instruct!(Val(2), state, YaoArrayRegister.Const.H, locs)
 end
-
 
 function YaoAPI.instruct!(::Val{2},
     state::AbstractVecOrMat{T},
@@ -345,15 +273,15 @@ function rot_mat(::Type{T}, gen::AbstractMatrix, theta::Real) where {N,T}
     end
 end
 # Specialized
-rot_mat(::Type{T}, ::Val{:Rx}, theta::Number) where {T} =
+parametric_mat(::Type{T}, ::Val{:Rx}, theta::Number) where {T} =
     T[cos(theta / 2) -im*sin(theta / 2); -im*sin(theta / 2) cos(theta / 2)]
-rot_mat(::Type{T}, ::Val{:Ry}, theta::Number) where {T} =
+parametric_mat(::Type{T}, ::Val{:Ry}, theta::Number) where {T} =
     T[cos(theta / 2) -sin(theta / 2); sin(theta / 2) cos(theta / 2)]
-rot_mat(::Type{T}, ::Val{:Rz}, theta::Number) where {T} =
+parametric_mat(::Type{T}, ::Val{:Rz}, theta::Number) where {T} =
     Diagonal(T[exp(-im * theta / 2), exp(im * theta / 2)])
-rot_mat(::Type{T}, ::Val{:CPHASE}, theta::Number) where {T} =
+parametric_mat(::Type{T}, ::Val{:CPHASE}, theta::Number) where {T} =
     Diagonal(T[1, 1, 1, exp(im * theta)])
-rot_mat(::Type{T}, ::Val{:PSWAP}, theta::Number) where {T} = rot_mat(T, Const.SWAP, theta)
+parametric_mat(::Type{T}, ::Val{:PSWAP}, theta::Number) where {T} = rot_mat(T, Const.SWAP, theta)
 
 for G in [:Rx, :Ry, :Rz, :CPHASE]
     # forward single gates
@@ -365,7 +293,7 @@ for G in [:Rx, :Ry, :Rz, :CPHASE]
         control_bits::NTuple{N2,Int},
         theta::Number,
     ) where {T,N1,N2,N3}
-        m = rot_mat(T, g, theta)
+        m = parametric_mat(T, g, theta)
         instruct!(Val(2), state, m, locs, control_locs, control_bits)
         return state
     end
@@ -410,7 +338,7 @@ function YaoAPI.instruct!(::Val{2},
     locs::NTuple{N,Int},
     theta::Number,
 ) where {T,N}
-    m = rot_mat(T, Val(:CPHASE), theta)
+    m = parametric_mat(T, Val(:CPHASE), theta)
     instruct!(Val(2), state, m, locs)
     return state
 end

--- a/lib/YaoArrayRegister/src/instruct.jl
+++ b/lib/YaoArrayRegister/src/instruct.jl
@@ -265,7 +265,7 @@ function YaoAPI.instruct!(::Val{2},
     bit_parity = iseven(length(locs)) ? 1 : -1
     factor = T(-im)^length(locs)
 
-    @threads for b in basis(Int, state)
+    @threads for b in basis(state)
         if anyone(b, do_mask)
             i = b + 1
             i_ = flip(b, mask) + 1
@@ -283,7 +283,7 @@ function YaoAPI.instruct!(::Val{2},
     locs::NTuple{N,Int},
 ) where {T,N}
     mask = bmask(Int, locs)
-    @threads for b in basis(Int, state)
+    @threads for b in basis(state)
         if isodd(count_ones(b & mask))
             mulrow!(state, b + 1, -1)
         end
@@ -301,7 +301,7 @@ for (G, FACTOR) in zip(
         locs::NTuple{N,Int},
     ) where {T,N}
         mask = bmask(Int, locs)
-        @threads for b in basis(Int, state)
+        @threads for b in basis(state)
             mulrow!(state, b + 1, $FACTOR^count_ones(b & mask))
         end
         return state

--- a/lib/YaoArrayRegister/src/instruct.jl
+++ b/lib/YaoArrayRegister/src/instruct.jl
@@ -176,11 +176,11 @@ function YaoAPI.instruct!(::Val{2},
 end
 
 function YaoAPI.instruct!(::Val{2},
-    state::AbstractVecOrMat,
+    state::AbstractVecOrMat{T},
     ::Val{:H},
     locs::NTuple{N,Int},
-) where {N}
-    instruct!(Val(2), state, YaoArrayRegister.Const.H, locs)
+) where {T, N}
+    instruct!(Val(2), state, matchtype(T, YaoArrayRegister.Const.H), locs)
 end
 
 function YaoAPI.instruct!(::Val{2},

--- a/lib/YaoArrayRegister/src/qudit_instruct.jl
+++ b/lib/YaoArrayRegister/src/qudit_instruct.jl
@@ -1,0 +1,160 @@
+using SparseArrays
+function YaoAPI.instruct!(::Val{D},
+    state::AbstractVecOrMat{T},
+    operator::AbstractMatrix{T},
+    locs::NTuple{M,Int},
+    control_locs::NTuple{C,Int},
+    control_bits::NTuple{C,Int}
+) where {T,M,C,D}
+    if length(control_locs) !== 0 || length(control_bits) !== 0
+        error("controlled qudit gates are not supported!")
+    end
+    if M == 1
+        return single_qubit_instruct!(state, operator, locs, control_locs, control_bits)
+    end
+    return instruct!(Val(D), state, operator, locs)
+end
+
+function YaoAPI.instruct!(::Val{D},
+    state::AbstractVecOrMat{T},
+    operator::AbstractMatrix{T},
+    locs::NTuple{M,Int},
+) where {T,M,D}
+    # prepare instruct
+    operator = sort_unitary(Val{D}(), operator, locs)
+    ndits = logdi(size(state, 1), D)
+    qudit_instruct!(Val{D}(), ndits, state, autostatic(operator), TupleTools.sort(locs))
+end
+
+function qudit_instruct!(::Val{D}, nbits::Int, state::AbstractVecOrMat{T}, operator::AbstractMatrix{T}, locs::NTuple{M,Int}) where {T,M,D}
+    strides = ntuple(i->D^(i-1), nbits)
+    baselocs = (setdiff(1:nbits, locs)...,)
+    basestrides = map(i->strides[i], baselocs)
+    substrides = map(i->strides[i], locs)
+
+    subindices = SVector(ntuple(i->map_index(Val(D), i-1, substrides), D^M))
+    #baseindices = [map_index(Val(D), i, basestrides) for i=0:D^(nbits-M)-1]
+
+    _instruct!(Val(D), state, autostatic(operator), subindices, basestrides)
+    return state
+end
+
+# specialize: IMatrix
+function qudit_instruct!(::Val{D}, nbits::Int, state::AbstractVecOrMat{T}, operator::IMatrix, locs::NTuple{M,Int}) where {T,M,D}
+    return state
+end
+
+@generated function _instruct!(::Val{D}, state::AbstractVecOrMat, U::AbstractMatrix, subindices::SVector, basestrides::NTuple{BN}) where {D,BN}
+    quote
+        sumc = 1 - sum(basestrides)
+        Base.Cartesian.@nloops($BN, i, d->1:$D,
+                d->(@inbounds sumc += i_d*basestrides[d]), # PRE
+                d->(@inbounds sumc -= i_d*basestrides[d]), # POST
+                begin # BODY
+                    @inbounds unrows!(state, subindices .+ sumc, U)
+                end)
+
+    end
+end
+@inline function map_index(::Val{D}, x, strides::NTuple{M,Int}) where {D,M}
+    res = zero(x)
+    for i=1:M
+        x, rem = divrem(x, D)
+        res += rem * strides[i]
+    end
+    return x
+end
+
+# specialize: Diagonal
+function qudit_instruct!(::Val{D},
+    nbits::Int,
+    state::AbstractVecOrMat{T},
+    operator::SDDiagonal{T},
+    locs::NTuple{M,Int},
+) where {T,M,D}
+    # create stride for indexing
+    strides = ntuple(i->D^(i-1), nbits)
+    baselocs = (setdiff(1:nbits, locs)...,)
+    basestrides = map(i->strides[i], baselocs)
+    substrides = map(i->strides[i], locs)
+
+    # allocate storage
+    CI = CartesianIndices(ntuple(i->D, M))
+    @threads for i=1:size(operator, 1)  # very limited multi-threading power
+        # set indices
+        @inbounds I = CI[i].I
+        @inbounds ioffset = sum(i->(I[i]-1) * substrides[i], 1:M)
+        instrloop_diag!(Val(D), state, operator.diag[i], ioffset, basestrides)
+    end
+    return state
+end
+
+@generated function instrloop_diag!(::Val{D}, state::AbstractVecOrMat, v, ioffset::Int, basestrides::NTuple{BN}) where {D,BN}
+    quote
+        sumc = 1 - sum(basestrides)
+        Base.Cartesian.@nloops($BN, i, d->1:$D,
+                d->(@inbounds sumc += i_d*basestrides[d]), # PRE
+                d->(@inbounds sumc -= i_d*basestrides[d]), # POST
+                begin # BODY
+                    @inbounds mulrow!(state, ioffset + sumc, v)
+                end)
+
+    end
+end
+
+# function qudit_instruct!(::Val{D}, nbits::Int, state::AbstractVecOrMat{T}, operator::SDSparseMatrixCSC{T}, locs::NTuple{M,Int}) where {T,M,D}
+#     stateout = zero(state)
+#     accum_instruct!(Val(D), nbits, stateout, state, TupleTools.sort(locs), autostatic(operator))
+#     return copyto!(state, stateout)
+# end
+
+# function accum_instruct!(::Val{D}, nbits::Int, stateout::AbstractVecOrMat{T}, statein::AbstractVecOrMat{T}, locs::NTuple{C}, mat::IMatrix) where {D,C,T}
+#     return stateout .+= statein
+# end
+
+# function accum_instruct!(::Val{D}, nbits::Int, stateout::AbstractVecOrMat{T}, statein::AbstractVecOrMat{T}, locs::NTuple{C}, mat::SDSparseMatrixCSC) where {D,C,T}
+#     @assert size(stateout) == size(statein)
+#     # create stride for indexing
+#     strides = ntuple(i->D^(i-1), nbits)
+#     baselocs = (setdiff(1:nbits, locs)...,)
+#     basestrides = map(i->strides[i], baselocs)
+#     substrides = map(i->strides[i], locs)
+
+#     # allocate storage
+#     CI = CartesianIndices(ntuple(i->D, C))
+#     @inbounds for (i, j, v) in zip(findnz(mat)...)
+#         # set indices
+#         I, J = CI[i].I, CI[j].I
+#         ioffset = sum(i->(I[i]-1) * substrides[i], 1:C)
+#         joffset = sum(i->(J[i]-1) * substrides[i], 1:C)
+#         instrloop!(Val(D), stateout, statein, v, ioffset, joffset, basestrides)
+#     end
+#     return stateout
+# end
+
+# @generated function instrloop!(::Val{D}, stateout::AbstractVecOrMat, statein::AbstractVecOrMat, v, ioffset::Int, joffset::Int, basestrides::NTuple{BN}) where {D,BN}
+#     quote
+#         sumc = 1 - sum(basestrides)
+#         Base.Cartesian.@nloops($BN, i, d->1:$D,
+#                 d->(@inbounds sumc += i_d*basestrides[d]), # PRE
+#                 d->(@inbounds sumc -= i_d*basestrides[d]), # POST
+#                 begin # BODY
+#                     @inbounds accrow!(stateout, ioffset + sumc, statein, joffset + sumc, v)
+#                 end)
+
+#     end
+# end
+
+# @inline function accrow!(stateout::AbstractVector, iout, statein::AbstractVector, iin, v)
+#     @inbounds stateout[iout] += v * statein[iin]
+# end
+
+# @inline function accrow!(stateout::AbstractMatrix, iout, statein::AbstractMatrix, iin, v)
+#     for j=size(stateout, 2)
+#         @inbounds stateout[iout, j] += v * statein[iin, j]
+#     end
+# end
+
+# TODO: add single qudit gate instruction.
+# TODO: add diagonal qudit gate instruction.
+# TODO: speed up sparse matrix and pm matrix gate.

--- a/lib/YaoArrayRegister/src/qudit_instruct.jl
+++ b/lib/YaoArrayRegister/src/qudit_instruct.jl
@@ -9,9 +9,7 @@ function YaoAPI.instruct!(::Val{D},
     if length(control_locs) !== 0 || length(control_bits) !== 0
         error("controlled qudit gates are not supported!")
     end
-    if M == 1
-        return single_qubit_instruct!(state, operator, locs, control_locs, control_bits)
-    end
+    # TODO: add single qudit optimization
     return instruct!(Val(D), state, operator, locs)
 end
 
@@ -102,59 +100,5 @@ end
     end
 end
 
-# function qudit_instruct!(::Val{D}, nbits::Int, state::AbstractVecOrMat{T}, operator::SDSparseMatrixCSC{T}, locs::NTuple{M,Int}) where {T,M,D}
-#     stateout = zero(state)
-#     accum_instruct!(Val(D), nbits, stateout, state, TupleTools.sort(locs), autostatic(operator))
-#     return copyto!(state, stateout)
-# end
-
-# function accum_instruct!(::Val{D}, nbits::Int, stateout::AbstractVecOrMat{T}, statein::AbstractVecOrMat{T}, locs::NTuple{C}, mat::IMatrix) where {D,C,T}
-#     return stateout .+= statein
-# end
-
-# function accum_instruct!(::Val{D}, nbits::Int, stateout::AbstractVecOrMat{T}, statein::AbstractVecOrMat{T}, locs::NTuple{C}, mat::SDSparseMatrixCSC) where {D,C,T}
-#     @assert size(stateout) == size(statein)
-#     # create stride for indexing
-#     strides = ntuple(i->D^(i-1), nbits)
-#     baselocs = (setdiff(1:nbits, locs)...,)
-#     basestrides = map(i->strides[i], baselocs)
-#     substrides = map(i->strides[i], locs)
-
-#     # allocate storage
-#     CI = CartesianIndices(ntuple(i->D, C))
-#     @inbounds for (i, j, v) in zip(findnz(mat)...)
-#         # set indices
-#         I, J = CI[i].I, CI[j].I
-#         ioffset = sum(i->(I[i]-1) * substrides[i], 1:C)
-#         joffset = sum(i->(J[i]-1) * substrides[i], 1:C)
-#         instrloop!(Val(D), stateout, statein, v, ioffset, joffset, basestrides)
-#     end
-#     return stateout
-# end
-
-# @generated function instrloop!(::Val{D}, stateout::AbstractVecOrMat, statein::AbstractVecOrMat, v, ioffset::Int, joffset::Int, basestrides::NTuple{BN}) where {D,BN}
-#     quote
-#         sumc = 1 - sum(basestrides)
-#         Base.Cartesian.@nloops($BN, i, d->1:$D,
-#                 d->(@inbounds sumc += i_d*basestrides[d]), # PRE
-#                 d->(@inbounds sumc -= i_d*basestrides[d]), # POST
-#                 begin # BODY
-#                     @inbounds accrow!(stateout, ioffset + sumc, statein, joffset + sumc, v)
-#                 end)
-
-#     end
-# end
-
-# @inline function accrow!(stateout::AbstractVector, iout, statein::AbstractVector, iin, v)
-#     @inbounds stateout[iout] += v * statein[iin]
-# end
-
-# @inline function accrow!(stateout::AbstractMatrix, iout, statein::AbstractMatrix, iin, v)
-#     for j=size(stateout, 2)
-#         @inbounds stateout[iout, j] += v * statein[iin, j]
-#     end
-# end
-
 # TODO: add single qudit gate instruction.
-# TODO: add diagonal qudit gate instruction.
 # TODO: speed up sparse matrix and pm matrix gate.

--- a/lib/YaoArrayRegister/src/qudit_instruct.jl
+++ b/lib/YaoArrayRegister/src/qudit_instruct.jl
@@ -46,7 +46,7 @@ end
 
 @generated function _instruct!(::Val{D}, state::AbstractVecOrMat, U::AbstractMatrix, subindices::SVector, basestrides::NTuple{BN}) where {D,BN}
     quote
-        sumc = 1 - sum(basestrides)
+        sumc = length(basestrides) == 0 ? 1 : 1 - sum(basestrides)
         Base.Cartesian.@nloops($BN, i, d->1:$D,
                 d->(@inbounds sumc += i_d*basestrides[d]), # PRE
                 d->(@inbounds sumc -= i_d*basestrides[d]), # POST
@@ -62,7 +62,7 @@ end
         x, rem = divrem(x, D)
         res += rem * strides[i]
     end
-    return x
+    return res
 end
 
 # specialize: Diagonal

--- a/lib/YaoArrayRegister/src/register.jl
+++ b/lib/YaoArrayRegister/src/register.jl
@@ -466,7 +466,7 @@ julia> product_state(bit"100"; nbatch=2);
 
 julia> r1 = product_state(ComplexF32, bit"001"; nbatch=2);
 
-julia> r2 = product_state(ComplexF32, [0, 0, 1]; nbatch=2);
+julia> r2 = product_state(ComplexF32, [1, 0, 0]; nbatch=2);
 
 julia> r3 = product_state(ComplexF32, 3, 0b001; nbatch=2);
 

--- a/lib/YaoArrayRegister/src/register.jl
+++ b/lib/YaoArrayRegister/src/register.jl
@@ -419,7 +419,7 @@ ArrayReg{2, ComplexF64, Array...}
     nlevel: 2
 
 julia> measure(reg; nshots=3)
-3-element Vector{BitBasis.BitStr64{6}}:
+3-element Vector{DitStr{2, 6, Int64}}:
  111000 ₍₂₎
  111000 ₍₂₎
  111000 ₍₂₎
@@ -452,13 +452,19 @@ See also [`zero_state`](@ref), [`rand_state`](@ref), [`uniform_state`](@ref).
 ### Examples
 
 ```jldoctest; setup=:(using Yao)
-julia> reg = product_state(dit"120/3"; nbatch=2)
+julia> reg = product_state(dit"120;3"; nbatch=2)
+BatchedArrayReg{3, ComplexF64, Transpose...}
+    active qudits: 3/3
+    nlevel: 3
+    nbatch: 2
 
 julia> measure(reg)
+1×2 Matrix{BitBasis.DitStr64{3, 3}}:
+ 120 ₍₃₎  120 ₍₃₎
 
 julia> product_state(bit"100"; nbatch=2);
 
-julia> r1 = product_state(ComplexF32, bit"100"; nbatch=2);
+julia> r1 = product_state(ComplexF32, bit"001"; nbatch=2);
 
 julia> r2 = product_state(ComplexF32, [0, 0, 1]; nbatch=2);
 
@@ -759,7 +765,7 @@ Find `n` most probable qubit configurations in a quantum register and return the
 
 ```jldoctest; setup=:(using Yao)
 julia> most_probable(ghz_state(3), 2)
-2-element Vector{BitBasis.BitStr64{3}}:
+2-element Vector{DitStr{2, 3, Int64}}:
  000 ₍₂₎
  111 ₍₂₎
 ```
@@ -785,7 +791,7 @@ Returns an `UnitRange` of the all the bits in the Hilbert space of given registe
 
 ```jldoctest; setup=:(using Yao)
 julia> collect(basis(rand_state(3)))
-8-element Vector{BitBasis.BitStr64{3}}:
+8-element Vector{DitStr{2, 3, Int64}}:
  000 ₍₂₎
  001 ₍₂₎
  010 ₍₂₎

--- a/lib/YaoArrayRegister/src/register.jl
+++ b/lib/YaoArrayRegister/src/register.jl
@@ -805,3 +805,6 @@ BitBasis.basis(r::AbstractRegister{D}) where D = basis(DitStr{D,nactive(r),Int})
 Curried version of `partial_tr(ρ, locs)`.
 """
 YaoAPI.partial_tr(locs) = @λ(ρ -> partial_tr(ρ, locs))
+
+Base.getindex(reg::ArrayReg{D}, d::DitStr{D}) where D = getindex(reg.state, buffer(d)+1)
+Base.getindex(reg::BatchedArrayReg{D}, d::DitStr{D}) where D = getindex(reg.state, buffer(d)+1, :)

--- a/lib/YaoArrayRegister/src/register.jl
+++ b/lib/YaoArrayRegister/src/register.jl
@@ -673,6 +673,25 @@ function Base.show(io::IO, reg::BatchedArrayReg{D,T,MT}) where {D,T,MT}
     print(io, "\n    nbatch: ", nbatch(reg))
 end
 
+print_table(reg::AbstractArrayReg; digits::Int=5) = print_table(stdout, reg; digits)
+function print_table(io::IO, reg::AbstractArrayReg; digits::Int=5)
+    data = rank3(reg)
+    for i in basis(reg)
+        print(io, "$i   ")
+        for b in 1:size(data, 3)
+            for r in 1:size(data, 2)
+                s = round(data[buffer(i)+1,r,b]; digits)
+                print(io, s)
+                if r != size(data, 2)
+                    print(io, ", ")
+                end
+            end
+            b !== size(data, 3) && print(io, "; ")
+        end
+        println(io)
+    end
+end
+
 """
     mutual_information(reg::AbstractArrayReg, part1, part2)
 

--- a/lib/YaoArrayRegister/src/register.jl
+++ b/lib/YaoArrayRegister/src/register.jl
@@ -462,7 +462,7 @@ julia> r1 = product_state(ComplexF32, bit"100"; nbatch=2);
 
 julia> r2 = product_state(ComplexF32, [0, 0, 1]; nbatch=2);
 
-julia> r3 = product_state(ComplexF32, 3, 0b1001; nbatch=2);
+julia> r3 = product_state(ComplexF32, 3, 0b001; nbatch=2);
 
 julia> r1 ≈ r2   # because we read bit strings from right to left, vectors from left to right.
 true
@@ -777,7 +777,7 @@ julia> collect(basis(rand_state(3)))
  111 ₍₂₎
 ```
 """
-BitBasis.basis(r::AbstractRegister{2}) = basis(BitStr{nactive(r),Int})
+BitBasis.basis(r::AbstractRegister{D}) where D = basis(DitStr{D,nactive(r),Int})
 
 
 """

--- a/lib/YaoArrayRegister/src/register.jl
+++ b/lib/YaoArrayRegister/src/register.jl
@@ -684,7 +684,7 @@ end
 
 Print configuration-amplitude pairs of the `register`.
 
-```jldoctest
+```jldoctest; setup=:(using Yao)
 julia> reg = ghz_state(2);
 
 julia> print_table(ghz_state(2))

--- a/lib/YaoArrayRegister/src/register.jl
+++ b/lib/YaoArrayRegister/src/register.jl
@@ -679,6 +679,21 @@ function Base.show(io::IO, reg::BatchedArrayReg{D,T,MT}) where {D,T,MT}
     print(io, "\n    nbatch: ", nbatch(reg))
 end
 
+"""
+    print_table([io::IO, ]register; digits::Int=5)
+
+Print configuration-amplitude pairs of the `register`.
+
+```jldoctest
+julia> reg = ghz_state(2);
+
+julia> print_table(ghz_state(2))
+00 ₍₂₎   0.70711 - 0.0im
+01 ₍₂₎   0.0 + 0.0im
+10 ₍₂₎   0.0 + 0.0im
+11 ₍₂₎   0.70711 - 0.0im
+```
+"""
 print_table(reg::AbstractArrayReg; digits::Int=5) = print_table(stdout, reg; digits)
 function print_table(io::IO, reg::AbstractArrayReg; digits::Int=5)
     data = rank3(reg)

--- a/lib/YaoArrayRegister/src/utils.jl
+++ b/lib/YaoArrayRegister/src/utils.jl
@@ -494,9 +494,9 @@ end
     end
 end
 
-function matchtype(::Type{T}, A::AbstractMatrix{T2}) where {T,T2}
+function matchtype(::Type{T}, A::AbstractArray{T2}) where {T,T2}
     return copyto!(similar(A, T), A)
 end
-function matchtype(::Type{T}, A::AbstractMatrix{T}) where {T}
+function matchtype(::Type{T}, A::AbstractArray{T}) where {T}
     return A
 end

--- a/lib/YaoArrayRegister/src/utils.jl
+++ b/lib/YaoArrayRegister/src/utils.jl
@@ -17,7 +17,8 @@ function sort_unitary(::Val{D}, U::AbstractMatrix, locs::NTuple{N,Int}) where {D
     if all(each > 0 for each in tuple_diff(locs))
         return U
     else
-        return permutedims(reshape(U, fill(D)...), TupleTools.sortperm(TupleTools.sortperm(locs)))
+        pm = TupleTools.sortperm(TupleTools.sortperm(locs))
+        return reshape(permutedims(reshape(U, fill(D, 2*N)...), (pm..., pm .+ N...)), size(U))
     end
 end
 

--- a/lib/YaoArrayRegister/src/utils.jl
+++ b/lib/YaoArrayRegister/src/utils.jl
@@ -13,11 +13,11 @@ end
 
 Return an sorted unitary operator according to the locations.
 """
-function sort_unitary(U::AbstractMatrix, locs::NTuple{N,Int}) where {N}
+function sort_unitary(::Val{D}, U::AbstractMatrix, locs::NTuple{N,Int}) where {D,N}
     if all(each > 0 for each in tuple_diff(locs))
         return U
     else
-        return reorder(U, TupleTools.sortperm(locs))
+        return permutedims(reshape(U, fill(D)...), TupleTools.sortperm(TupleTools.sortperm(locs)))
     end
 end
 

--- a/lib/YaoArrayRegister/src/utils.jl
+++ b/lib/YaoArrayRegister/src/utils.jl
@@ -494,3 +494,9 @@ end
     end
 end
 
+function matchtype(::Type{T}, A::AbstractMatrix{T2}) where {T,T2}
+    return copyto!(similar(A, T), A)
+end
+function matchtype(::Type{T}, A::AbstractMatrix{T}) where {T}
+    return A
+end

--- a/lib/YaoArrayRegister/test/instruct.jl
+++ b/lib/YaoArrayRegister/test/instruct.jl
@@ -200,3 +200,15 @@ end
     @test isapprox(norm(statevec(reg2)), 1.0; atol = 1e-5)
     @test isapprox(statevec(reg1), statevec(reg2))
 end
+
+@testset "push coverage" begin
+    state = randn(ComplexF64, 3^5)
+    # identity fallback
+    @test instruct!(Val(3), copy(state), IMatrix{3,ComplexF64}(), (1,)) == state
+    U = randn(ComplexF64,3,3)
+    # error on control
+    @test_throws ErrorException instruct!(Val(3), state, U, (1,), (2,), (4,))
+    @test instruct!(Val(3), copy(state), U, (1,), (), ()) ≈ instruct!(Val(3), copy(state), U, (1,))
+    U2 = randn(ComplexF64,9,9)
+    @test instruct!(Val(3), copy(state), U2, (3,1), (), ()) ≈ instruct!(Val(3), copy(state), U2, (3,1))
+end

--- a/lib/YaoArrayRegister/test/measure.jl
+++ b/lib/YaoArrayRegister/test/measure.jl
@@ -60,3 +60,7 @@ end
     @test_throws MethodError measure!(r; nshots = 10)
     @test_throws MethodError measure!(YaoAPI.RemoveMeasured(), r; nshots = 10)
 end
+
+@testset "measure qudits" begin
+    @test measure(product_state(dit"121;3")) == [dit"121;3"]
+end

--- a/lib/YaoArrayRegister/test/measure.jl
+++ b/lib/YaoArrayRegister/test/measure.jl
@@ -51,7 +51,7 @@ end
 
 @testset "fix measure output type error" begin
     res = measure(rand_state(1; nbatch = 10))
-    @test res isa Matrix{BitStr64{1}}
+    @test res isa Matrix{<:BitStr{1}}
 end
 
 @testset "fix measure kwargs error" begin

--- a/lib/YaoArrayRegister/test/operations.jl
+++ b/lib/YaoArrayRegister/test/operations.jl
@@ -14,15 +14,15 @@ end
     reg1 = zero_state(5)
     reg2 = arrayreg(bit"00100")
     @test reg1 != reg2
-    @test statevec(reg2) == onehot(ComplexF64, nbit, 4)
+    @test statevec(reg2) == onehot(ComplexF64, BitStr64{nbit}(4))
     reg3 = reg1 + reg2
     reg4 = (reg1 + reg2)'
 
-    @test statevec(reg3) == onehot(ComplexF64, nbit, 4) + onehot(ComplexF64, nbit, 0)
+    @test statevec(reg3) == onehot(ComplexF64, BitStr64{nbit}(4)) + onehot(ComplexF64, BitStr64{nbit}(0))
     @test statevec(reg3 |> normalize!) ==
-          (onehot(ComplexF64, nbit, 4) + onehot(ComplexF64, nbit, 0)) / sqrt(2)
+          (onehot(ComplexF64, BitStr64{nbit}(4)) + onehot(ComplexF64, BitStr64{nbit}(0))) / sqrt(2)
     @test statevec(reg4 |> normalize!) ==
-          (onehot(ComplexF64, nbit, 4) + onehot(ComplexF64, nbit, 0))' / sqrt(2)
+          (onehot(ComplexF64, BitStr64{nbit}(4)) + onehot(ComplexF64, BitStr64{nbit}(0)))' / sqrt(2)
     @test (reg1 + reg2 - reg1) == reg2
     @test reg1' + reg2' - reg1' == reg2'
     @test isnormalized(reg4)

--- a/lib/YaoArrayRegister/test/qudit_instruct.jl
+++ b/lib/YaoArrayRegister/test/qudit_instruct.jl
@@ -1,0 +1,14 @@
+using YaoArrayRegister
+using Test, LinearAlgebra
+using YaoArrayRegister: accum_instruct!
+using SparseArrays: sprand
+
+@testset "operators" begin
+    state = rand_state(6) |> statevec
+    # general matrix
+    for m in [YaoArrayRegister.IMatrix{1<<12,ComplexF64}(), randn(ComplexF64, 4, 4), YaoArrayRegister.pmrand(ComplexF64, 4), Diagonal(randn(ComplexF64, 4)), sprand(ComplexF64, 4, 4, 0.5)]
+        @info "qudit gate, matrix type: ", typeof(m)
+        expected = instruct!(Val(2), state, m, (3,4))
+        @test expected ≈ instruct!(Val(4), state, m, (2,))
+    end
+end

--- a/lib/YaoArrayRegister/test/qudit_instruct.jl
+++ b/lib/YaoArrayRegister/test/qudit_instruct.jl
@@ -2,12 +2,31 @@ using YaoArrayRegister
 using Test, LinearAlgebra
 using SparseArrays: sprand
 
+@testset "utils" begin
+    @test YaoArrayRegister.map_index(Val(3), 5, (1,3)) == 5
+    @test YaoArrayRegister.map_index(Val(3), 5, (3,1)) == 7
+end
+
 @testset "operators" begin
     state = rand_state(6) |> statevec
     # general matrix
-    for m in [YaoArrayRegister.IMatrix{1<<12,ComplexF64}(), randn(ComplexF64, 4, 4), YaoArrayRegister.pmrand(ComplexF64, 4), Diagonal(randn(ComplexF64, 4)), sprand(ComplexF64, 4, 4, 0.5)]
+    for m in [YaoArrayRegister.IMatrix{1<<2,ComplexF64}(), randn(ComplexF64, 4, 4), YaoArrayRegister.pmrand(ComplexF64, 4), Diagonal(randn(ComplexF64, 4)), sprand(ComplexF64, 4, 4, 0.5)]
         @info "qudit gate, matrix type: ", typeof(m)
         expected = instruct!(Val(2), state, m, (3,4))
         @test expected ≈ instruct!(Val(4), state, m, (2,))
     end
+end
+
+@testset "corner cases" begin
+    state = rand_state(2) |> statevec
+    # matrix size same as register size
+    m = randn(ComplexF64, 4, 4)
+    expected = instruct!(Val(2), state, m, (1,2))
+    @test expected ≈ instruct!(Val(4), state, m, (1,))
+
+    # an case that breaks during test
+    state = randn(ComplexF64, 3)
+    m = sparse([1, 2], [2,1], [1.0+0im, 1.0], 3, 3)
+    expected = m * state
+    @test expected ≈ instruct!(Val(3), state, m, (1,))
 end

--- a/lib/YaoArrayRegister/test/qudit_instruct.jl
+++ b/lib/YaoArrayRegister/test/qudit_instruct.jl
@@ -1,6 +1,5 @@
 using YaoArrayRegister
 using Test, LinearAlgebra
-using YaoArrayRegister: accum_instruct!
 using SparseArrays: sprand
 
 @testset "operators" begin

--- a/lib/YaoArrayRegister/test/register.jl
+++ b/lib/YaoArrayRegister/test/register.jl
@@ -318,4 +318,7 @@ end
 
 @testset "basis" begin
     @test basis(rand_state(3)) == bit"000":bit"111"
+    reg = product_state(dit"120;3")
+    @test reg[dit"120;3"] == 1.0
+    @test reg[dit"121;3"] == 0.0
 end

--- a/lib/YaoArrayRegister/test/register.jl
+++ b/lib/YaoArrayRegister/test/register.jl
@@ -24,6 +24,9 @@ using Adapt
     @test similar(reg, m).state == m
     @test viewbatch(reg, 1) == reg
     @test_throws ErrorException viewbatch(reg, 2)
+
+    reg = rand_state(3; nlevel=3, nbatch=2) |> focus!((2,3))
+    print_table(reg)
 end
 
 @testset "test BatchedArrayReg constructors" begin

--- a/lib/YaoArrayRegister/test/register.jl
+++ b/lib/YaoArrayRegister/test/register.jl
@@ -79,7 +79,7 @@ end
 
         st = state(product_state(T, 4, 0; nbatch = 3))
         for k = 1:3
-            @test st[:, k] ≈ onehot(T, 4, 0)
+            @test st[:, k] ≈ onehot(T, BitStr64{4}(0))
         end
         @test eltype(product_state(Float64, 4, 0).state) == Float64
     end
@@ -91,7 +91,7 @@ end
         st = state(zero_state(T, 4; nbatch = 4))
         @test st isa Transpose
         for k = 1:4
-            @test st[:, k] ≈ onehot(T, 4, 0)
+            @test st[:, k] ≈ onehot(T, BitStr64{4}(0))
         end
         @test eltype(zero_state(Float64, 4).state) == Float64
     end

--- a/lib/YaoArrayRegister/test/runtests.jl
+++ b/lib/YaoArrayRegister/test/runtests.jl
@@ -15,6 +15,10 @@ end
     include("instruct.jl")
 end
 
+@testset "test qudit instructions" begin
+    include("qudit_instruct.jl")
+end
+
 @testset "test measure" begin
     include("measure.jl")
 end

--- a/lib/YaoArrayRegister/test/utils.jl
+++ b/lib/YaoArrayRegister/test/utils.jl
@@ -157,3 +157,8 @@ end
     @test logdi(9, 3) == 2
     @test_throws ArgumentError logdi(9, 5)
 end
+
+@testset "matchtype" begin
+    @test YaoArrayRegister.matchtype(ComplexF64, randn(2,2)) isa Array{ComplexF64}
+    @test YaoArrayRegister.matchtype(ComplexF64, randn(ComplexF64, 2,2)) isa Array{ComplexF64}
+end

--- a/lib/YaoBlocks/Project.toml
+++ b/lib/YaoBlocks/Project.toml
@@ -21,7 +21,7 @@ YaoAPI = "0843a435-28de-4971-9e8b-a9641b2983a8"
 YaoArrayRegister = "e600142f-9330-5003-8abb-0ebd767abc51"
 
 [compat]
-BitBasis = "0.7"
+BitBasis = "0.8"
 CacheServers = "0.2"
 ChainRulesCore = "1.11"
 ExponentialUtilities = "1.5"

--- a/lib/YaoBlocks/src/YaoBlocks.jl
+++ b/lib/YaoBlocks/src/YaoBlocks.jl
@@ -93,7 +93,9 @@ export AbstractBlock,
     ishermitian,
     nparameters,
     rand_unitary,
-    rand_hermitian
+    rand_hermitian,
+    EntryTable,
+    cleanup
 
 export applymatrix, cache_key
 

--- a/lib/YaoBlocks/src/abstract_block.jl
+++ b/lib/YaoBlocks/src/abstract_block.jl
@@ -448,46 +448,28 @@ dispatch(x::AbstractBlock, it) = dispatch(nothing, x, it)
 BitBasis.basis(b::AbstractBlock{D}) where D = basis(DitStr{D,nqudits(b),Int64})
 
 ################## get index ###################
+
 function Base.getindex(b::AbstractBlock{D}, i::DitStr{D,N}, j::DitStr{D,N}) where {D,N}
+    T = promote_type(ComplexF64, parameters_eltype(b))
     @assert nqudits(b) == N
-    return unsafe_getindex(b, buffer(i), buffer(j))
+    return unsafe_getindex(T, b, buffer(i), buffer(j))
 end
-struct EntryTable{IT<:DitStr, ET}
-    configs::Vector{IT}
-    amplitudes::Vector{ET}
-end
-function Base.Vector(et::EntryTable{<:DitStr{D,N}, ET}) where {D,N,ET}
-    v = zeros(ET, D^N)
-    for (c, a) in zip(et.configs, et.amplitudes)
-        v[buffer(c)+1] = a
-    end
-    return v
-end
-function SparseArrays.SparseVector(et::EntryTable{<:DitStr{D,N}, ET}) where {D,N,ET}
-    locs = buffer.(et.configs) .+ 1
-    order = sortperm(locs)
-    return SparseVector(D^N, locs[order], et.amplitudes[order])
-end
-SparseArrays.sparse(et::EntryTable) = SparseVector(et)
-Base.vec(et::EntryTable) = Vector(et)
-
-function YaoArrayRegister.print_table(io::IO, t::EntryTable; digits::Int=5)
-    println(io, "$(typeof(t)):")
-    for (i, a) in zip(t.configs, t.amplitudes)
-        println(io, "  $i   $(round(a; digits))")
-    end
-end
-Base.show(io::IO, ::MIME"text/plain", t::EntryTable) = YaoArrayRegister.print_table(io, t; digits=5)
-Base.show(io::IO, t::EntryTable) = YaoArrayRegister.print_table(io, t; digits=5)
-
-
 function Base.getindex(b::AbstractBlock{D}, ::Colon, j::DitStr{D,N,TI}) where {D,N,TI}
     @assert nqudits(b) == N
-    rows, vals = unsafe_getcol(b, j)
+    T = promote_type(ComplexF64, parameters_eltype(b))
+    rows, vals = unsafe_getcol(T, b, j)
     return EntryTable(rows, vals)
 end
 function Base.getindex(b::AbstractBlock{D}, i::DitStr{D,N,TI}, ::Colon) where {D,N,TI}
-    @assert nqudits(b) == N
-    rows, vals = unsafe_getcol(b', i)
-    return EntryTable(rows, conj!(vals))
+    res = b'[:,i]
+    conj!(res.amplitudes)
+    return res
+end
+function Base.getindex(b::AbstractBlock{D}, ::Colon, j::EntryTable{DitStr{D,N,TI},T}) where {D,N,TI,T}
+    return merge([(et = b[:,bs]; rmul!(et.amplitudes, amp); et) for (bs, amp) in zip(j.configs, j.amplitudes)]...)
+end
+function Base.getindex(b::AbstractBlock{D}, i::EntryTable{DitStr{D,N,TI},T}, ::Colon) where {D,N,TI,T}
+    res = b'[:,i]
+    conj!(res.amplitudes)
+    return res
 end

--- a/lib/YaoBlocks/src/abstract_block.jl
+++ b/lib/YaoBlocks/src/abstract_block.jl
@@ -444,3 +444,9 @@ function dispatch(f::Union{Function,Nothing}, x::AbstractBlock, it)
 end
 
 dispatch(x::AbstractBlock, it) = dispatch(nothing, x, it)
+
+BitBasis.basis(b::AbstractBlock{D}) where D = basis(DitStr{D,nqudits(b),Int64})
+function BitBasis.getindex(b::AbstractBlock{D}, i::DitStr{D,N}, j::DitStr{D,N}) where {D,N}
+    @assert nqudits(b) == N
+    return unsafe_getindex(b, buffer(i), buffer(j))
+end

--- a/lib/YaoBlocks/src/abstract_block.jl
+++ b/lib/YaoBlocks/src/abstract_block.jl
@@ -417,17 +417,7 @@ Check `apply!` for the faster inplace version.
 """
 # overwrite interface, this one avoids one copy
 function apply(reg::AbstractRegister{D}, block) where D
-    if D == 2
-        return apply!(copy(reg), block)
-    else
-        YaoBlocks._check_size(reg, block)
-        operator = sort_unitary_d(mat(block.content), block.locs)
-        state = statevec(reg)
-        nbits = logdi(size(state, 1), D)
-        stateout = zero(state)
-        accum_instruct!(Val(D), nbits, stateout, state, TupleTools.sort(block.locs), YaoArrayRegister.autostatic(operator))
-        return ArrayReg{D}(stateout)
-    end
+    return apply!(copy(reg), block)
 end
 
 function generic_dispatch!(f::Union{Function,Nothing}, x::AbstractBlock, it::Dispatcher)

--- a/lib/YaoBlocks/src/abstract_block.jl
+++ b/lib/YaoBlocks/src/abstract_block.jl
@@ -446,7 +446,7 @@ end
 dispatch(x::AbstractBlock, it) = dispatch(nothing, x, it)
 
 BitBasis.basis(b::AbstractBlock{D}) where D = basis(DitStr{D,nqudits(b),Int64})
-function BitBasis.getindex(b::AbstractBlock{D}, i::DitStr{D,N}, j::DitStr{D,N}) where {D,N}
+function Base.getindex(b::AbstractBlock{D}, i::DitStr{D,N}, j::DitStr{D,N}) where {D,N}
     @assert nqudits(b) == N
     return unsafe_getindex(b, buffer(i), buffer(j))
 end

--- a/lib/YaoBlocks/src/abstract_block.jl
+++ b/lib/YaoBlocks/src/abstract_block.jl
@@ -482,7 +482,7 @@ function _getindex(b::AbstractBlock{D}, ::Colon, j::EntryTable{DitStr{D,N,TI},T}
     return merge([(et = b[:,bs]; rmul!(et.amplitudes, amp); et) for (bs, amp) in zip(j.configs, j.amplitudes)]...)
 end
 function _getindex(b::AbstractBlock{D}, i::EntryTable{DitStr{D,N,TI},T}, ::Colon) where {D,N,TI,T}
-    res = b'[:,i]
+    res = _getindex(b',:,i)
     conj!(res.amplitudes)
     return res
 end

--- a/lib/YaoBlocks/src/algebra.jl
+++ b/lib/YaoBlocks/src/algebra.jl
@@ -31,7 +31,7 @@ Base.:(/)(A::AbstractBlock, x::Number) = (1 / x) * A
 # reduce
 Base.prod(blocks::AbstractVector{<:AbstractBlock{D}}) where D =
     chain(Iterators.reverse(blocks)...)
-Base.sum(blocks::AbstractVector{<:AbstractBlock{D}}) where D = +(blocks...)
+Base.sum(blocks::AbstractVector{<:AbstractBlock{D}}) where D = Add(blocks)
 
 #sub
 Base.:(-)(lhs::AbstractBlock, rhs::AbstractBlock) = Add(lhs, -rhs)

--- a/lib/YaoBlocks/src/autodiff/apply_back.jl
+++ b/lib/YaoBlocks/src/autodiff/apply_back.jl
@@ -125,7 +125,7 @@ function apply_back!(st, circuit::ChainBlock, collector)
     return st
 end
 
-function apply_back!(st, circuit::Add, collector; in)
+function apply_back!(st, circuit::AbstractAdd, collector; in)
     out, outδ = st
     adjmat = outerprod(outδ, in)
     for blk in Base.Iterators.reverse(subblocks(circuit))

--- a/lib/YaoBlocks/src/autodiff/chainrules_patch.jl
+++ b/lib/YaoBlocks/src/autodiff/chainrules_patch.jl
@@ -83,7 +83,7 @@ function rrule(::typeof(apply), reg::AbstractArrayReg, block::AbstractBlock)
         return (NoTangent(), inδ, create_circuit_tangent(block, paramsδ))
     end
 end
-function rrule(::typeof(apply), reg::AbstractArrayReg, block::Add)
+function rrule(::typeof(apply), reg::AbstractArrayReg, block::AbstractAdd)
     out = apply(reg, block)
     out, function (outδ)
         (in, inδ), paramsδ = apply_back((copy(out), outδ), block; in = reg)

--- a/lib/YaoBlocks/src/autodiff/mat_back.jl
+++ b/lib/YaoBlocks/src/autodiff/mat_back.jl
@@ -104,7 +104,7 @@ function mat_back!(::Type{T}, rb::KronBlock, adjy, collector) where {T}
     return collector
 end
 
-function mat_back!(::Type{T}, rb::Add, adjy, collector) where {T}
+function mat_back!(::Type{T}, rb::AbstractAdd, adjy, collector) where {T}
     nparameters(rb) == 0 && return collector
     for b in subblocks(rb)[end:-1:1]
         mat_back!(T, b, adjy, collector)

--- a/lib/YaoBlocks/src/blocktools.jl
+++ b/lib/YaoBlocks/src/blocktools.jl
@@ -122,7 +122,7 @@ function expect(op::AbstractBlock, reg::BatchedArrayReg)
 end
 
 for REG in [:ArrayReg, :BatchedArrayReg]
-    @eval function expect(op::Add, reg::$REG)
+    @eval function expect(op::AbstractAdd, reg::$REG)
         sum(opi -> expect(opi, reg), op)
     end
     @eval function expect(op::Scale, reg::$REG)

--- a/lib/YaoBlocks/src/composite/add.jl
+++ b/lib/YaoBlocks/src/composite/add.jl
@@ -1,7 +1,10 @@
-export Add
+export Add, AbstractAdd
+
+# We need this abstract type for supporting Hamiltonian types.
+abstract type AbstractAdd{D} <: CompositeBlock{D} end
 
 """
-    Add{D} <: CompositeBlock{D}
+    Add{D} <: AbstractAdd{D}
     Add(blocks::AbstractBlock...) -> Add
 
 Type for block addition.
@@ -14,7 +17,7 @@ nqubits: 1
 └─ X
 ```
 """
-struct Add{D} <: CompositeBlock{D}
+struct Add{D} <: AbstractAdd{D}
     n::Int
     list::Vector{AbstractBlock{D}}
     Add(n::Int, blocks::Vector{AbstractBlock{D}}) where {D} = new{D}(_check_block_sizes(blocks, n), blocks)
@@ -28,19 +31,21 @@ Add(blocks::AbstractVector{<:AbstractBlock{D}}) where {D} = Add(collect(Abstract
 Add(block::AbstractBlock{D}, blocks::AbstractBlock{D}...) where {D} = Add(AbstractBlock{D}[block, blocks...])
 nqudits(add::Add) = add.n
 
-function mat(::Type{T}, x::Add{D}) where {D,T}
-    length(x.list) == 0 && return Diagonal(zeros(T, D^x.n))
-    mapreduce(x -> mat(T, x), +, x.list)
+function mat(::Type{T}, x::AbstractAdd{D}) where {D,T}
+    blocks = subblocks(x)
+    length(blocks) == 0 && return Diagonal(zeros(T, D^x.n))
+    mapreduce(x -> mat(T, x), +, blocks)
 end
 
 chsubblocks(x::Add, it) = Add(it)
 
-function YaoAPI.unsafe_apply!(r::AbstractRegister, x::Add)
-    isempty(x.list) && return r
-    length(x.list) == 1 && return YaoAPI.unsafe_apply!(r, x.list[])
+function YaoAPI.unsafe_apply!(r::AbstractRegister, x::AbstractAdd)
+    blocks = subblocks(x)
+    isempty(blocks) && return r
+    length(blocks) == 1 && return YaoAPI.unsafe_apply!(r, blocks[])
 
-    res = mapreduce(blk -> YaoAPI.unsafe_apply!(copy(r), blk), regadd!, x.list[1:end-1])
-    YaoAPI.unsafe_apply!(r, x.list[end])
+    res = mapreduce(blk -> YaoAPI.unsafe_apply!(copy(r), blk), regadd!, blocks[1:end-1])
+    YaoAPI.unsafe_apply!(r, blocks[end])
     regadd!(r, res)
     r
 end
@@ -48,9 +53,9 @@ end
 export Add
 
 subblocks(x::Add) = x.list
-cache_key(x::Add) = map(cache_key, x.list)
-Base.copy(x::Add) = Add(x.n, copy(x.list))
-Base.similar(c::Add) = Add(c.n, empty!(similar(c.list)))
+cache_key(x::Add) = map(cache_key, subblocks(x))
+Base.copy(x::Add) = Add(x.n, copy(subblocks(x)))
+Base.similar(c::Add) = Add(c.n, empty!(similar(subblocks(c))))
 
 function Base.:(==)(lhs::Add{D}, rhs::Add{D}) where {D}
     nqudits(lhs) == nqudits(rhs) && (length(lhs.list) == length(rhs.list)) && all(lhs.list .== rhs.list)
@@ -66,10 +71,10 @@ Base.setindex!(c::Add{D}, val::AbstractBlock{D}, index::Integer) where {D} =
     (setindex!(c.list, val, index); c)
 Base.insert!(c::Add{D}, index::Integer, val::AbstractBlock{D}) where {D} =
     (insert!(c.list, index, val); c)
-Base.adjoint(blk::Add{D}) where {D} = Add(blk.n, map(adjoint, subblocks(blk)))
+Base.adjoint(blk::AbstractAdd{D}) where {D} = chsubblocks(blk, map(adjoint, subblocks(blk)))
 
 ## Iterate contained blocks
-occupied_locs(c::Add) =
+occupied_locs(c::AbstractAdd) =
     (unique(Iterators.flatten(occupied_locs(b) for b in subblocks(c)))...,)
 
 # Additional Methods for Add
@@ -93,39 +98,41 @@ function Base.prepend!(c::Add, list)
     c
 end
 
-LinearAlgebra.ishermitian(ad::Add) = all(ishermitian, ad.list) || ishermitian(mat(ad))
+LinearAlgebra.ishermitian(ad::AbstractAdd) = all(ishermitian, subblocks(ad)) || ishermitian(mat(ad))
 
 # this is not type stable, possible to fix?
-function unsafe_getindex(::Type{T}, ad::Add{D}, i::Integer, j::Integer) where {T, D}
-    length(ad.list) > 0 ? sum(b->unsafe_getindex(T,b,i,j), ad.list) : zero(T)
+function unsafe_getindex(::Type{T}, ad::AbstractAdd{D}, i::Integer, j::Integer) where {T, D}
+    blocks = subblocks(ad)
+    isempty(blocks) ? sum(b->unsafe_getindex(T,b,i,j), subblocks(ad)) : zero(T)
 end
-function unsafe_getcol(::Type{T}, ad::Add{D}, j::DitStr{D,N,TI}) where {T,D,N,TI}
-    length(ad.list) == 0 && return DitStr{D,N,TI}[], T[]
+function unsafe_getcol(::Type{T}, ad::AbstractAdd{D}, j::DitStr{D,N,TI}) where {T,D,N,TI}
+    blocks = subblocks(ad)
+    isempty(blocks) && return DitStr{D,N,TI}[], T[]
     locs = Vector{DitStr{D,N,TI}}[]
     amps = Vector{T}[]
-    for block in ad.list
+    for block in blocks
         loc, amp = unsafe_getcol(T, block, j)
         push!(locs, loc)
         push!(amps, amp)
     end
     return vcat(locs...), vcat(amps...)
 end
-function Base.getindex(b::Add{D}, i::DitStr{D,N}, j::DitStr{D,N}) where {D,N}
+function Base.getindex(b::AbstractAdd{D}, i::DitStr{D,N}, j::DitStr{D,N}) where {D,N}
     invoke(Base.getindex, Tuple{AbstractBlock{D}, DitStr{D,N}, DitStr{D,N}} where {D,N}, b, i, j)
 end
-function Base.getindex(b::Add{D}, ::Colon, j::DitStr{D,N}) where {D,N}
+function Base.getindex(b::AbstractAdd{D}, ::Colon, j::DitStr{D,N}) where {D,N}
     T = promote_type(ComplexF64, parameters_eltype(b))
     return _getindex(T, b, :, j)
 end
-function Base.getindex(b::Add{D}, i::DitStr{D,N}, ::Colon) where {D,N}
+function Base.getindex(b::AbstractAdd{D}, i::DitStr{D,N}, ::Colon) where {D,N}
     T = promote_type(ComplexF64, parameters_eltype(b))
     return _getindex(T, b, i, :)
 end
 # the performance of this block important! so specialize it will make it slightly faster.
-function Base.getindex(ad::Add{D}, ::Colon, j::EntryTable{DitStr{D,N,TI},T}) where {D,N,TI,T}
+function Base.getindex(ad::AbstractAdd{D}, ::Colon, j::EntryTable{DitStr{D,N,TI},T}) where {D,N,TI,T}
     cfgs = Vector{DitStr{D,N,TI}}[]
     amps = Vector{T}[]
-    for b in ad.list
+    for b in subblocks(ad)
         _single_block!(cfgs, amps, b, j)
     end
     return merge(EntryTable(vcat(cfgs...), vcat(amps...)))
@@ -138,6 +145,6 @@ function _single_block!(cfgs, amps, b, j::EntryTable)
         push!(amps, et.amplitudes)
     end
 end
-function Base.getindex(ad::Add{D}, i::EntryTable{DitStr{D,N,TI},T}, ::Colon) where {D,N,TI,T}
+function Base.getindex(ad::AbstractAdd{D}, i::EntryTable{DitStr{D,N,TI},T}, ::Colon) where {D,N,TI,T}
     return _getindex(ad, i, :)
 end

--- a/lib/YaoBlocks/src/composite/add.jl
+++ b/lib/YaoBlocks/src/composite/add.jl
@@ -113,9 +113,17 @@ end
 function Base.getindex(b::Add{D}, i::DitStr{D,N}, j::DitStr{D,N}) where {D,N}
     invoke(Base.getindex, Tuple{AbstractBlock{D}, DitStr{D,N}, DitStr{D,N}} where {D,N}, b, i, j)
 end
-function Base.getindex(b::Add{D}, i::Colon, j::DitStr{D,N}) where {D,N}
-    invoke(Base.getindex, Tuple{AbstractBlock{D}, Colon, DitStr{D}} where D, b, i, j)
+function Base.getindex(b::Add{D}, ::Colon, j::DitStr{D,N}) where {D,N}
+    T = promote_type(ComplexF64, parameters_eltype(b))
+    return _getindex(T, b, :, j)
 end
-function Base.getindex(b::Add{D}, i::DitStr{D,N}, j::DitStr{D,N}) where {D,N}
-    invoke(Base.getindex, Tuple{AbstractBlock{D}, DitStr{D}, D} where D, b, i, j)
+function Base.getindex(b::Add{D}, i::DitStr{D,N}, ::Colon) where {D,N}
+    T = promote_type(ComplexF64, parameters_eltype(b))
+    return _getindex(T, b, i, :)
+end
+function Base.getindex(b::Add{D}, ::Colon, j::EntryTable{DitStr{D,N,TI},T}) where {D,N,TI,T}
+    return _getindex(b, :, j)
+end
+function Base.getindex(b::Add{D}, i::EntryTable{DitStr{D,N,TI},T}, ::Colon) where {D,N,TI,T}
+    return _getindex(b, i, :)
 end

--- a/lib/YaoBlocks/src/composite/add.jl
+++ b/lib/YaoBlocks/src/composite/add.jl
@@ -94,3 +94,12 @@ function Base.prepend!(c::Add, list)
 end
 
 LinearAlgebra.ishermitian(ad::Add) = all(ishermitian, ad.list) || ishermitian(mat(ad))
+
+# this is not type stable, possible to fix?
+function unsafe_getindex(ad::Add{D}, i::Integer, j::Integer) where D
+    length(ad.list) > 0 ? sum(b->unsafe_getindex(b,i,j), ad.list) : 0.0im
+end
+function Base.getindex(b::Add{D}, i::DitStr{D,N}, j::DitStr{D,N}) where {D,N}
+    @assert nqudits(b) == N
+    return unsafe_getindex(b, buffer(i), buffer(j))
+end

--- a/lib/YaoBlocks/src/composite/chain.jl
+++ b/lib/YaoBlocks/src/composite/chain.jl
@@ -218,8 +218,16 @@ function Base.getindex(b::ChainBlock{D}, i::DitStr{D,N}, j::DitStr{D,N}) where {
     invoke(Base.getindex, Tuple{AbstractBlock{D}, DitStr{D,N}, DitStr{D,N}} where {D,N}, b, i, j)
 end
 function Base.getindex(b::ChainBlock{D}, ::Colon, j::DitStr{D,N}) where {D,N}
-    invoke(Base.getindex, Tuple{AbstractBlock{D}, Colon, DitStr{D,N}} where {D,N}, b, :, j)
+    T = promote_type(ComplexF64, parameters_eltype(b))
+    return _getindex(T, b, :, j)
 end
 function Base.getindex(b::ChainBlock{D}, i::DitStr{D,N}, ::Colon) where {D,N}
-    invoke(Base.getindex, Tuple{AbstractBlock{D}, DitStr{D,N}, Colon} where {D,N}, b, i, :)
+    T = promote_type(ComplexF64, parameters_eltype(b))
+    return _getindex(T, b, i, :)
+end
+function Base.getindex(b::ChainBlock{D}, ::Colon, j::EntryTable{DitStr{D,N,TI},T}) where {D,N,TI,T}
+    return _getindex(b, :, j)
+end
+function Base.getindex(b::ChainBlock{D}, i::EntryTable{DitStr{D,N,TI},T}, ::Colon) where {D,N,TI,T}
+    return _getindex(b, i, :)
 end

--- a/lib/YaoBlocks/src/composite/chain.jl
+++ b/lib/YaoBlocks/src/composite/chain.jl
@@ -177,3 +177,12 @@ YaoAPI.isreflexive(c::ChainBlock) =
     (iscommute(c.blocks...) && all(isreflexive, c.blocks)) || isreflexive(mat(c))
 LinearAlgebra.ishermitian(c::ChainBlock) =
     (all(isreflexive, c.blocks) && iscommute(c.blocks...)) || isreflexive(mat(c))
+
+# this is not type stable, possible to fix?
+function unsafe_getindex(ad::ChainBlock{D}, i::Integer, j::Integer) where D
+    #length(ad.list) > 0 ? sum(b->unsafe_getindex(b,i,j), ad.list) : 0.0im
+end
+function Base.getindex(b::ChainBlock{D}, i::DitStr{D,N}, j::DitStr{D,N}) where {D,N}
+    @assert nqudits(b) == N
+    return unsafe_getindex(b, buffer(i), buffer(j))
+end

--- a/lib/YaoBlocks/src/composite/chain.jl
+++ b/lib/YaoBlocks/src/composite/chain.jl
@@ -179,7 +179,16 @@ LinearAlgebra.ishermitian(c::ChainBlock) =
     (all(isreflexive, c.blocks) && iscommute(c.blocks...)) || isreflexive(mat(c))
 
 # this is not type stable, possible to fix?
-function unsafe_getindex(ad::ChainBlock{D}, i::Integer, j::Integer) where D
+function unsafe_getindex(c::ChainBlock{D}, i::Integer, j::Integer) where D
+    if length(c) == 0
+        return i==j ? 1.0+0im : 0.0im
+    elseif length(c) == 1
+        return unsafe_getindex(c.blocks[1], i, j)
+    else
+        # TODO: change this slow implementation
+        return mat(c)[i+1, j+1]
+        #error("get index of a chain is not yet supported! Try use [`kron`](@ref), [`repeat`](@ref), [`put`](@ref) or file an issue.")
+    end
     #length(ad.list) > 0 ? sum(b->unsafe_getindex(b,i,j), ad.list) : 0.0im
 end
 function Base.getindex(b::ChainBlock{D}, i::DitStr{D,N}, j::DitStr{D,N}) where {D,N}

--- a/lib/YaoBlocks/src/composite/chain.jl
+++ b/lib/YaoBlocks/src/composite/chain.jl
@@ -115,6 +115,7 @@ occupied_locs(c::ChainBlock) =
 chsubblocks(pb::ChainBlock{D}, blocks::Vector{<:AbstractBlock{D}}) where {D} =
     length(blocks) == 0 ? ChainBlock(pb.n, AbstractBlock{D}[]) : ChainBlock(pb.n, blocks)
 chsubblocks(pb::ChainBlock, it) = chain(it...)
+chsubblocks(x::ChainBlock, it::AbstractBlock) = chsubblocks(x, (it,))
 
 function mat(::Type{T}, c::ChainBlock{D}) where {T,D}
     if isempty(c.blocks)

--- a/lib/YaoBlocks/src/composite/composite.jl
+++ b/lib/YaoBlocks/src/composite/composite.jl
@@ -66,10 +66,6 @@ include("subroutine.jl")
 include("add.jl")
 include("unitary_channel.jl")
 
-chsubblocks(x::ChainBlock, it::AbstractBlock) = chsubblocks(x, (it,))
-chsubblocks(x::KronBlock, it::AbstractBlock) = chsubblocks(x, (it,))
-chsubblocks(x::Add, it::AbstractBlock) = chsubblocks(x, (it,))
-
 # tag blocks
 include("tag/tag.jl")
 include("tag/cache.jl")

--- a/lib/YaoBlocks/src/composite/composite.jl
+++ b/lib/YaoBlocks/src/composite/composite.jl
@@ -63,7 +63,7 @@ include("control.jl")
 include("put_block.jl")
 include("repeated.jl")
 include("subroutine.jl")
-include("reduce.jl")
+include("add.jl")
 include("unitary_channel.jl")
 
 chsubblocks(x::ChainBlock, it::AbstractBlock) = chsubblocks(x, (it,))

--- a/lib/YaoBlocks/src/composite/control.jl
+++ b/lib/YaoBlocks/src/composite/control.jl
@@ -187,3 +187,7 @@ function YaoAPI.iscommute(x::ControlBlock, y::ControlBlock)
         return iscommute_fallback(x, y)
     end
 end
+
+function unsafe_getindex(ctrl::ControlBlock{D}, i::Integer, j::Integer) where D
+    getindex2(ComplexF64, Val{2}(), nqudits(ctrl), ctrl.content, ctrl.locs, ctrl.ctrl_locs, ctrl.ctrl_config, i, j)
+end

--- a/lib/YaoBlocks/src/composite/control.jl
+++ b/lib/YaoBlocks/src/composite/control.jl
@@ -189,8 +189,8 @@ function YaoAPI.iscommute(x::ControlBlock, y::ControlBlock)
 end
 
 function unsafe_getindex(::Type{T}, ctrl::ControlBlock, i::Integer, j::Integer) where {T,D}
-    getindex2(T, Val{2}(), nqudits(ctrl), ctrl.content, ctrl.locs, ctrl.ctrl_locs, ctrl.ctrl_config, i, j)
+    instruct_get_element(T, Val{2}(), nqudits(ctrl), ctrl.content, ctrl.locs, ctrl.ctrl_locs, ctrl.ctrl_config, i, j)
 end
 function unsafe_getcol(::Type{T}, ctrl::ControlBlock, j::DitStr{D}) where {T,D}
-    getindexr(T, ctrl.content, ctrl.locs, ctrl.ctrl_locs, ctrl.ctrl_config, j)
+    instruct_get_column(T, ctrl.content, ctrl.locs, ctrl.ctrl_locs, ctrl.ctrl_config, j)
 end

--- a/lib/YaoBlocks/src/composite/control.jl
+++ b/lib/YaoBlocks/src/composite/control.jl
@@ -188,6 +188,9 @@ function YaoAPI.iscommute(x::ControlBlock, y::ControlBlock)
     end
 end
 
-function unsafe_getindex(ctrl::ControlBlock{D}, i::Integer, j::Integer) where D
-    getindex2(ComplexF64, Val{2}(), nqudits(ctrl), ctrl.content, ctrl.locs, ctrl.ctrl_locs, ctrl.ctrl_config, i, j)
+function unsafe_getindex(::Type{T}, ctrl::ControlBlock, i::Integer, j::Integer) where {T,D}
+    getindex2(T, Val{2}(), nqudits(ctrl), ctrl.content, ctrl.locs, ctrl.ctrl_locs, ctrl.ctrl_config, i, j)
+end
+function unsafe_getcol(::Type{T}, ctrl::ControlBlock, j::DitStr{D}) where {T,D}
+    getindexr(T, ctrl.content, ctrl.locs, ctrl.ctrl_locs, ctrl.ctrl_config, j)
 end

--- a/lib/YaoBlocks/src/composite/kron.jl
+++ b/lib/YaoBlocks/src/composite/kron.jl
@@ -217,8 +217,8 @@ YaoAPI.isunitary(k::KronBlock) = all(isunitary, k.blocks) || isunitary(mat(k))
 YaoAPI.isreflexive(k::KronBlock) = all(isreflexive, k.blocks) || isreflexive(mat(k))
 
 function unsafe_getindex(::Type{T}, k::KronBlock{D}, i::Integer, j::Integer) where {T,D}
-    kron_getindex2(T, Val{D}(), nqudits(k), k.blocks, k.locs, i, j)
+    kron_instruct_get_element(T, Val{D}(), nqudits(k), k.blocks, k.locs, i, j)
 end
 function unsafe_getcol(::Type{T}, pb::KronBlock{D}, j::DitStr{D}) where {T,D}
-    kron_getindexr(T, pb.blocks, pb.locs, j)
+    kron_instruct_get_column(T, pb.blocks, pb.locs, j)
 end

--- a/lib/YaoBlocks/src/composite/kron.jl
+++ b/lib/YaoBlocks/src/composite/kron.jl
@@ -149,6 +149,7 @@ Base.kron(blocks::Base.Generator) = kron(blocks...)
 occupied_locs(k::KronBlock) = (vcat([[getindex.(Ref(loc), occupied_locs(b))...] for (loc, b) in zip(k.locs, k.blocks)]...)...,)
 subblocks(x::KronBlock) = x.blocks
 chsubblocks(pb::KronBlock, it) = KronBlock(pb.n, pb.locs, (it...,))
+chsubblocks(x::KronBlock, it::AbstractBlock) = chsubblocks(x, (it,))
 cache_key(x::KronBlock) = [cache_key(each) for each in x.blocks]
 color(::Type{T}) where {T<:KronBlock} = :cyan
 

--- a/lib/YaoBlocks/src/composite/kron.jl
+++ b/lib/YaoBlocks/src/composite/kron.jl
@@ -214,3 +214,7 @@ Base.adjoint(blk::KronBlock) = KronBlock(blk.n, blk.locs, map(adjoint, blk.block
 LinearAlgebra.ishermitian(k::KronBlock) = all(ishermitian, k.blocks) || ishermitian(mat(k))
 YaoAPI.isunitary(k::KronBlock) = all(isunitary, k.blocks) || isunitary(mat(k))
 YaoAPI.isreflexive(k::KronBlock) = all(isreflexive, k.blocks) || isreflexive(mat(k))
+
+function unsafe_getindex(k::KronBlock{D}, i::Integer, j::Integer) where {D}
+    kron_getindex2(ComplexF64, Val{D}(), nqudits(k), k.blocks, k.locs, i, j)
+end

--- a/lib/YaoBlocks/src/composite/kron.jl
+++ b/lib/YaoBlocks/src/composite/kron.jl
@@ -215,9 +215,9 @@ LinearAlgebra.ishermitian(k::KronBlock) = all(ishermitian, k.blocks) || ishermit
 YaoAPI.isunitary(k::KronBlock) = all(isunitary, k.blocks) || isunitary(mat(k))
 YaoAPI.isreflexive(k::KronBlock) = all(isreflexive, k.blocks) || isreflexive(mat(k))
 
-function unsafe_getindex(k::KronBlock{D}, i::Integer, j::Integer) where {D}
-    kron_getindex2(ComplexF64, Val{D}(), nqudits(k), k.blocks, k.locs, i, j)
+function unsafe_getindex(::Type{T}, k::KronBlock{D}, i::Integer, j::Integer) where {T,D}
+    kron_getindex2(T, Val{D}(), nqudits(k), k.blocks, k.locs, i, j)
 end
-function unsafe_getcol(pb::KronBlock{D}, j::DitStr{D}) where D
-    kron_getindexr(ComplexF64, pb.blocks, pb.locs, j)
+function unsafe_getcol(::Type{T}, pb::KronBlock{D}, j::DitStr{D}) where {T,D}
+    kron_getindexr(T, pb.blocks, pb.locs, j)
 end

--- a/lib/YaoBlocks/src/composite/kron.jl
+++ b/lib/YaoBlocks/src/composite/kron.jl
@@ -218,3 +218,6 @@ YaoAPI.isreflexive(k::KronBlock) = all(isreflexive, k.blocks) || isreflexive(mat
 function unsafe_getindex(k::KronBlock{D}, i::Integer, j::Integer) where {D}
     kron_getindex2(ComplexF64, Val{D}(), nqudits(k), k.blocks, k.locs, i, j)
 end
+function unsafe_getcol(pb::KronBlock{D}, j::DitStr{D}) where D
+    kron_getindexr(ComplexF64, pb.blocks, pb.locs, j)
+end

--- a/lib/YaoBlocks/src/composite/put_block.jl
+++ b/lib/YaoBlocks/src/composite/put_block.jl
@@ -148,7 +148,7 @@ swap(loc1::Int, loc2::Int) = @λ(n -> swap(n, loc1, loc2))
 
 function mat(::Type{T}, g::Swap) where {T}
     mask = bmask(g.locs[1], g.locs[2])
-    orders = map(b -> swapbits(b, mask) + 1, basis(g.n))
+    orders = map(b -> swapbits(b, mask) + 1, 0:1<<g.n-1)
     return PermMatrix(orders, ones(T, nlevel(g)^g.n))
 end
 

--- a/lib/YaoBlocks/src/composite/put_block.jl
+++ b/lib/YaoBlocks/src/composite/put_block.jl
@@ -188,8 +188,8 @@ for (G, GT) in [
 end
 
 function unsafe_getindex(::Type{T}, pb::PutBlock{D}, i::Integer, j::Integer) where {T,D}
-    getindex2(T, Val{D}(), nqudits(pb), pb.content, pb.locs, (), (), i, j)
+    instruct_get_element(T, Val{D}(), nqudits(pb), pb.content, pb.locs, (), (), i, j)
 end
 function unsafe_getcol(::Type{T}, pb::PutBlock{D}, j::DitStr{D}) where {T,D}
-    getindexr(T, pb.content, pb.locs, (), (), j)
+    instruct_get_column(T, pb.content, pb.locs, (), (), j)
 end

--- a/lib/YaoBlocks/src/composite/put_block.jl
+++ b/lib/YaoBlocks/src/composite/put_block.jl
@@ -187,9 +187,9 @@ for (G, GT) in [
     end
 end
 
-function unsafe_getindex(pb::PutBlock{D}, i::Integer, j::Integer) where D
-    getindex2(ComplexF64, Val{D}(), nqudits(pb), pb.content, pb.locs, (), (), i, j)
+function unsafe_getindex(::Type{T}, pb::PutBlock{D}, i::Integer, j::Integer) where {T,D}
+    getindex2(T, Val{D}(), nqudits(pb), pb.content, pb.locs, (), (), i, j)
 end
-function unsafe_getcol(pb::PutBlock{D}, j::DitStr{D}) where D
-    getindexr(ComplexF64, pb.content, pb.locs, (), (), j)
+function unsafe_getcol(::Type{T}, pb::PutBlock{D}, j::DitStr{D}) where {T,D}
+    getindexr(T, pb.content, pb.locs, (), (), j)
 end

--- a/lib/YaoBlocks/src/composite/put_block.jl
+++ b/lib/YaoBlocks/src/composite/put_block.jl
@@ -186,3 +186,7 @@ for (G, GT) in [
         return reg
     end
 end
+
+function unsafe_getindex(pb::PutBlock{D}, i::Integer, j::Integer) where D
+    getindex2(ComplexF64, Val{D}(), nqudits(pb), pb.content, pb.locs, (), (), i, j)
+end

--- a/lib/YaoBlocks/src/composite/put_block.jl
+++ b/lib/YaoBlocks/src/composite/put_block.jl
@@ -76,7 +76,9 @@ PropertyTrait(::PutBlock) = PreserveAll()
 cache_key(pb::PutBlock) = cache_key(pb.content)
 
 mat(::Type{T}, pb::PutBlock{2,1}) where {T} = u1mat(pb.n, mat(T, pb.content), pb.locs...)
-mat(::Type{T}, pb::PutBlock{2,C}) where {T,C} = unmat(pb.n, mat(T, pb.content), pb.locs)
+function mat(::Type{T}, pb::PutBlock{D,C}) where {T,D,C}
+    return unmat(Val{D}(), nqudits(pb), mat(T, pb.content), pb.locs)
+end
 
 function _apply!(r::AbstractRegister, pb::PutBlock{D}) where D
     instruct!(r, mat_matchreg(r, pb.content), pb.locs)

--- a/lib/YaoBlocks/src/composite/put_block.jl
+++ b/lib/YaoBlocks/src/composite/put_block.jl
@@ -190,3 +190,6 @@ end
 function unsafe_getindex(pb::PutBlock{D}, i::Integer, j::Integer) where D
     getindex2(ComplexF64, Val{D}(), nqudits(pb), pb.content, pb.locs, (), (), i, j)
 end
+function unsafe_getcol(pb::PutBlock{D}, j::DitStr{D}) where D
+    getindexr(ComplexF64, pb.content, pb.locs, (), (), j)
+end

--- a/lib/YaoBlocks/src/composite/reduce.jl
+++ b/lib/YaoBlocks/src/composite/reduce.jl
@@ -25,7 +25,7 @@ end
 Add(blocks::NTuple{M,AbstractBlock{D}}) where {M,D} = Add(collect(AbstractBlock{D}, blocks))
 Add(n::Int, blocks::AbstractVector{<:AbstractBlock{D}}) where {D} = Add(n, collect(AbstractBlock{D}, blocks))
 Add(blocks::AbstractVector{<:AbstractBlock{D}}) where {D} = Add(collect(AbstractBlock{D}, blocks))
-Add(blocks::AbstractBlock{D}...) where {D} = Add(collect(AbstractBlock{D}, blocks))
+Add(block::AbstractBlock{D}, blocks::AbstractBlock{D}...) where {D} = Add(AbstractBlock{D}[block, blocks...])
 nqudits(add::Add) = add.n
 
 function mat(::Type{T}, x::Add{D}) where {D,T}

--- a/lib/YaoBlocks/src/composite/repeated.jl
+++ b/lib/YaoBlocks/src/composite/repeated.jl
@@ -158,10 +158,10 @@ function YaoAPI.iscommute(x::RepeatedBlock{D}, y::RepeatedBlock{D}) where {D}
 end
 
 function unsafe_getindex(::Type{T}, rp::RepeatedBlock{D}, i::Integer, j::Integer) where {T,D}
-    repeat_getindex2(T, Val{D}(), nqudits(rp), rp.content, rp.locs, i, j)
+    repeat_instruct_get_element(T, Val{D}(), nqudits(rp), rp.content, rp.locs, i, j)
 end
 
 function unsafe_getcol(::Type{T}, pb::RepeatedBlock{D,C}, j::DitStr{D}) where {T,D,C}
     n = nqudits(pb.content)
-    kron_getindexr(T, ntuple(i->pb.content, C), ntuple(i->(pb.locs[i]:pb.locs[i]+n-1), C), j)
+    kron_instruct_get_column(T, ntuple(i->pb.content, C), ntuple(i->(pb.locs[i]:pb.locs[i]+n-1), C), j)
 end

--- a/lib/YaoBlocks/src/composite/repeated.jl
+++ b/lib/YaoBlocks/src/composite/repeated.jl
@@ -16,6 +16,8 @@ function RepeatedBlock(n::Int, block::AbstractBlock{D}, locs::NTuple{C,Int}) whe
     nqudits(block) > 1 && throw(
         ArgumentError("RepeatedBlock does not support multi-qubit content for the moment."),
     )
+    # sort the locations
+    locs = TupleTools.sort(locs)
     return RepeatedBlock{D,C,typeof(block)}(n, block, locs)
 end
 
@@ -153,4 +155,8 @@ function YaoAPI.iscommute(x::RepeatedBlock{D}, y::RepeatedBlock{D}) where {D}
     else
         iscommute_fallback(x, y)
     end
+end
+
+function unsafe_getindex(rp::RepeatedBlock{D}, i::Integer, j::Integer) where D
+    repeat_getindex2(ComplexF64, Val{D}(), nqudits(rp), rp.content, rp.locs, i, j)
 end

--- a/lib/YaoBlocks/src/composite/repeated.jl
+++ b/lib/YaoBlocks/src/composite/repeated.jl
@@ -157,6 +157,11 @@ function YaoAPI.iscommute(x::RepeatedBlock{D}, y::RepeatedBlock{D}) where {D}
     end
 end
 
-function unsafe_getindex(rp::RepeatedBlock{D}, i::Integer, j::Integer) where D
-    repeat_getindex2(ComplexF64, Val{D}(), nqudits(rp), rp.content, rp.locs, i, j)
+function unsafe_getindex(::Type{T}, rp::RepeatedBlock{D}, i::Integer, j::Integer) where {T,D}
+    repeat_getindex2(T, Val{D}(), nqudits(rp), rp.content, rp.locs, i, j)
+end
+
+function unsafe_getcol(::Type{T}, pb::RepeatedBlock{D,C}, j::DitStr{D}) where {T,D,C}
+    n = nqudits(pb.content)
+    kron_getindexr(T, ntuple(i->pb.content, C), ntuple(i->(pb.locs[i]:pb.locs[i]+n-1), C), j)
 end

--- a/lib/YaoBlocks/src/composite/subroutine.jl
+++ b/lib/YaoBlocks/src/composite/subroutine.jl
@@ -122,3 +122,7 @@ function YaoAPI.iscommute(x::Subroutine{D}, y::Subroutine{D}) where {D}
         return iscommute_fallback(x, y)
     end
 end
+
+function unsafe_getindex(sr::Subroutine{D}, i::Integer, j::Integer) where D
+    getindex2(ComplexF64, Val{D}(), nqudits(sr), sr.content, sr.locs, (), (), i, j)
+end

--- a/lib/YaoBlocks/src/composite/subroutine.jl
+++ b/lib/YaoBlocks/src/composite/subroutine.jl
@@ -124,8 +124,8 @@ function YaoAPI.iscommute(x::Subroutine{D}, y::Subroutine{D}) where {D}
 end
 
 function unsafe_getindex(::Type{T}, sr::Subroutine{D}, i::Integer, j::Integer) where {T,D}
-    getindex2(T, Val{D}(), nqudits(sr), sr.content, sr.locs, (), (), i, j)
+    instruct_get_element(T, Val{D}(), nqudits(sr), sr.content, sr.locs, (), (), i, j)
 end
 function unsafe_getcol(::Type{T}, pb::Subroutine{D}, j::DitStr{D}) where {T,D}
-    getindexr(T, pb.content, pb.locs, (), (), j)
+    instruct_get_column(T, pb.content, pb.locs, (), (), j)
 end

--- a/lib/YaoBlocks/src/composite/subroutine.jl
+++ b/lib/YaoBlocks/src/composite/subroutine.jl
@@ -123,6 +123,9 @@ function YaoAPI.iscommute(x::Subroutine{D}, y::Subroutine{D}) where {D}
     end
 end
 
-function unsafe_getindex(sr::Subroutine{D}, i::Integer, j::Integer) where D
-    getindex2(ComplexF64, Val{D}(), nqudits(sr), sr.content, sr.locs, (), (), i, j)
+function unsafe_getindex(::Type{T}, sr::Subroutine{D}, i::Integer, j::Integer) where {T,D}
+    getindex2(T, Val{D}(), nqudits(sr), sr.content, sr.locs, (), (), i, j)
+end
+function unsafe_getcol(::Type{T}, pb::Subroutine{D}, j::DitStr{D}) where {T,D}
+    getindexr(T, pb.content, pb.locs, (), (), j)
 end

--- a/lib/YaoBlocks/src/composite/tag/cache.jl
+++ b/lib/YaoBlocks/src/composite/tag/cache.jl
@@ -199,15 +199,23 @@ function unsafe_getindex(::Type{T}, c::CachedBlock, i::Integer, j::Integer) wher
     @inbounds mat(T, c)[i+1, j+1]
 end
 function unsafe_getcol(::Type{T}, c::CachedBlock, j::DitStr) where {T}
-    @inbounds mat(T, c)[:, j+1]
+    @inbounds getcol(mat(T, c), j)
 end
 
 function Base.getindex(b::CachedBlock{ST, BT, D}, i::DitStr{D,N}, j::DitStr{D,N}) where {ST,BT,D,N}
     invoke(Base.getindex, Tuple{AbstractBlock{D}, DitStr{D,N}, DitStr{D,N}} where {D,N}, b, i, j)
 end
-function Base.getindex(b::CachedBlock{ST, BT, D}, ::Colon, j::DitStr{D,N}) where {ST,BT,D,N}
-    invoke(Base.getindex, Tuple{AbstractBlock{D}, Colon, DitStr{D,N}} where {D,N}, b, :, j)
+function Base.getindex(b::CachedBlock{ST, BT, D}, ::Colon, j::DitStr{D,N}) where {D,N,ST,BT}
+    T = promote_type(ComplexF64, parameters_eltype(b))
+    return _getindex(T, b, :, j)
 end
-function Base.getindex(b::CachedBlock{ST, BT, D}, i::DitStr{D,N}, ::Colon) where {ST,BT,D,N}
-    invoke(Base.getindex, Tuple{AbstractBlock{D}, DitStr{D,N}, Colon} where {D,N}, b, i, :)
+function Base.getindex(b::CachedBlock{ST, BT, D}, i::DitStr{D,N}, ::Colon) where {D,N,ST,BT}
+    T = promote_type(ComplexF64, parameters_eltype(b))
+    return _getindex(T, b, i, :)
+end
+function Base.getindex(b::CachedBlock{ST, BT, D}, ::Colon, j::EntryTable{DitStr{D,N,TI},T}) where {D,N,TI,T,ST,BT}
+    return _getindex(b, :, j)
+end
+function Base.getindex(b::CachedBlock{ST, BT, D}, i::EntryTable{DitStr{D,N,TI},T}, ::Colon) where {D,N,TI,T,ST,BT}
+    return _getindex(b, i, :)
 end

--- a/lib/YaoBlocks/src/composite/tag/cache.jl
+++ b/lib/YaoBlocks/src/composite/tag/cache.jl
@@ -194,3 +194,12 @@ function cache(
 
     return CachedBlock(server, x, level)
 end
+
+function unsafe_getindex(c::CachedBlock, i::Integer, j::Integer)
+    @inbounds mat(c)[i+1, j+1]
+end
+
+function Base.getindex(b::CachedBlock{ST, BT, D}, i::DitStr{D,N}, j::DitStr{D,N}) where {ST,BT,D,N}
+    @assert nqudits(b) == N
+    return unsafe_getindex(b, buffer(i), buffer(j))
+end

--- a/lib/YaoBlocks/src/composite/tag/cache.jl
+++ b/lib/YaoBlocks/src/composite/tag/cache.jl
@@ -195,11 +195,19 @@ function cache(
     return CachedBlock(server, x, level)
 end
 
-function unsafe_getindex(c::CachedBlock, i::Integer, j::Integer)
-    @inbounds mat(c)[i+1, j+1]
+function unsafe_getindex(::Type{T}, c::CachedBlock, i::Integer, j::Integer) where T
+    @inbounds mat(T, c)[i+1, j+1]
+end
+function unsafe_getcol(::Type{T}, c::CachedBlock, j::DitStr) where {T}
+    @inbounds mat(T, c)[:, j+1]
 end
 
 function Base.getindex(b::CachedBlock{ST, BT, D}, i::DitStr{D,N}, j::DitStr{D,N}) where {ST,BT,D,N}
-    @assert nqudits(b) == N
-    return unsafe_getindex(b, buffer(i), buffer(j))
+    invoke(Base.getindex, Tuple{AbstractBlock{D}, DitStr{D,N}, DitStr{D,N}} where {D,N}, b, i, j)
+end
+function Base.getindex(b::CachedBlock{ST, BT, D}, ::Colon, j::DitStr{D,N}) where {ST,BT,D,N}
+    invoke(Base.getindex, Tuple{AbstractBlock{D}, Colon, DitStr{D,N}} where {D,N}, b, :, j)
+end
+function Base.getindex(b::CachedBlock{ST, BT, D}, i::DitStr{D,N}, ::Colon) where {ST,BT,D,N}
+    invoke(Base.getindex, Tuple{AbstractBlock{D}, DitStr{D,N}, Colon} where {D,N}, b, i, :)
 end

--- a/lib/YaoBlocks/src/composite/tag/dagger.jl
+++ b/lib/YaoBlocks/src/composite/tag/dagger.jl
@@ -58,7 +58,7 @@ end
 function force_getrowconj(::Type{T}, mb::GeneralMatrixBlock, i::DitStr{D}) where {T,D}
     locs, vals = getcol(mb.mat', i)
     if eltype(vals) != T
-        vals = convert.(Ref(T), vals)
+        vals = convert.(T, vals)
     end
     return locs, vals
 end

--- a/lib/YaoBlocks/src/composite/tag/dagger.jl
+++ b/lib/YaoBlocks/src/composite/tag/dagger.jl
@@ -48,6 +48,23 @@ Base.adjoint(x::AbstractBlock) = ishermitian(x) ? x : Daggered(x)
 Base.adjoint(x::Daggered) = content(x)
 Base.copy(x::Daggered) = Daggered(copy(content(x)))
 
-function unsafe_getindex(d::Daggered{D}, i::Integer, j::Integer) where D
-    return unsafe_getindex(content(d), j, i) |> conj
+function unsafe_getindex(::Type{T}, d::Daggered, i::Integer, j::Integer) where {T}
+    return unsafe_getindex(T, content(d), j, i) |> conj
+end
+function unsafe_getcol(::Type{T}, d::Daggered, j::DitStr{D}) where {T,D}
+    locs, vals = force_getrowconj(T, content(d), j)
+    return locs, vals
+end
+function force_getrowconj(::Type{T}, mb::GeneralMatrixBlock, i::DitStr{D}) where {T,D}
+    locs, vals = getcol(mb.mat', i)
+    if eltype(vals) != T
+        vals = convert.(Ref(T), vals)
+    end
+    return locs, vals
+end
+function force_getrowconj(::Type{T}, mb::AbstractBlock{D}, i::DitStr{D}) where {T,D}
+    if nqudits(mb) > 10  # for block size larger than 10, throw a warning
+        @warn "fallback to slow get row implementation! Try avoid using `Daggered` type or implement the `force_getrowconj` method for your block."
+    end
+    return getcol(mat(T, mb)', i)
 end

--- a/lib/YaoBlocks/src/composite/tag/dagger.jl
+++ b/lib/YaoBlocks/src/composite/tag/dagger.jl
@@ -47,3 +47,7 @@ chsubblocks(blk::Daggered, target::AbstractBlock) = Daggered(target)
 Base.adjoint(x::AbstractBlock) = ishermitian(x) ? x : Daggered(x)
 Base.adjoint(x::Daggered) = content(x)
 Base.copy(x::Daggered) = Daggered(copy(content(x)))
+
+function unsafe_getindex(d::Daggered{D}, i::Integer, j::Integer) where D
+    return unsafe_getindex(content(d), j, i) |> conj
+end

--- a/lib/YaoBlocks/src/composite/tag/scale.jl
+++ b/lib/YaoBlocks/src/composite/tag/scale.jl
@@ -62,3 +62,7 @@ function _apply!(r::AbstractArrayReg, x::Scale{S}) where {S}
     regscale!(r, factor(x))
     return r
 end
+
+function unsafe_getindex(x::Scale, i::Integer, j::Integer)
+    return unsafe_getindex(content(x), i, j) * factor(x)
+end

--- a/lib/YaoBlocks/src/composite/tag/scale.jl
+++ b/lib/YaoBlocks/src/composite/tag/scale.jl
@@ -63,6 +63,11 @@ function _apply!(r::AbstractArrayReg, x::Scale{S}) where {S}
     return r
 end
 
-function unsafe_getindex(x::Scale, i::Integer, j::Integer)
-    return unsafe_getindex(content(x), i, j) * factor(x)
+function unsafe_getindex(::Type{T}, x::Scale, i::Integer, j::Integer) where T
+    return unsafe_getindex(T, content(x), i, j) * factor(x)
+end
+
+function unsafe_getcol(::Type{T}, x::Scale, j::DitStr) where T
+    locs, vals = unsafe_getcol(T, content(x), j)
+    return locs, rmul!(vals, factor(x))
 end

--- a/lib/YaoBlocks/src/primitive/const_gate.jl
+++ b/lib/YaoBlocks/src/primitive/const_gate.jl
@@ -75,3 +75,28 @@ import .ConstGate:
 
 occupied_locs(::I2Gate) = ()
 nqudits(::ConstantGate{N}) where N = N
+
+function unsafe_getindex(::Type{T}, rg::XGate, i::Integer, j::Integer) where {T}
+    i==j ? zero(T) : one(T)
+end
+function unsafe_getindex(::Type{T}, rg::YGate, i::Integer, j::Integer) where {T}
+    if i==j
+        zero(T)
+    elseif i > j
+        T(im)
+    else
+        T(-im)
+    end
+end
+function unsafe_getindex(::Type{T}, rg::ZGate, i::Integer, j::Integer) where {T}
+    if i==j
+        if i==0
+            one(T)
+        else
+            -one(T)
+        end
+    else
+        zero(T)
+    end
+end
+# NOTE: no speedup if I specialize `unsafe_getcol`

--- a/lib/YaoBlocks/src/primitive/const_gate.jl
+++ b/lib/YaoBlocks/src/primitive/const_gate.jl
@@ -99,4 +99,20 @@ function unsafe_getindex(::Type{T}, rg::ZGate, i::Integer, j::Integer) where {T}
         zero(T)
     end
 end
-# NOTE: no speedup if I specialize `unsafe_getcol`
+# NOTE: The above function has no speedup if I specialize `unsafe_getcol`
+
+# NOTE: The following function fixes the problem of having too many entries when get a column.
+function unsafe_getcol(::Type{T}, rg::ConstGate.P0Gate, j::DitStr{2}) where {T}
+    if iszero(j)
+        return [j], [one(T)]
+    else
+        return typeof(j)[], T[]
+    end
+end
+function unsafe_getcol(::Type{T}, rg::ConstGate.P1Gate, j::DitStr{2}) where {T}
+    if iszero(j)
+        return typeof(j)[], T[]
+    else
+        return [j], [one(T)]
+    end
+end

--- a/lib/YaoBlocks/src/primitive/identity_gate.jl
+++ b/lib/YaoBlocks/src/primitive/identity_gate.jl
@@ -40,3 +40,10 @@ igate(2;nlevel=3)
 ```
 """
 igate(n::Int; nlevel=2) = IdentityGate{nlevel}(n)
+
+function unsafe_getindex(::Type{T}, rg::IdentityGate{D}, i::Integer, j::Integer) where {D,T}
+    i==j ? one(T) : zero(T)
+end
+function unsafe_getcol(::Type{T}, rg::IdentityGate{D}, j::DitStr{D}) where {D,T}
+    [j], [one(T)]
+end

--- a/lib/YaoBlocks/src/primitive/primitive.jl
+++ b/lib/YaoBlocks/src/primitive/primitive.jl
@@ -21,3 +21,25 @@ YaoAPI.isdiagonal(p::PrimitiveBlock) = isdiagonal(mat(p))
 function unsafe_getindex(op::PrimitiveBlock{D}, i::Integer, j::Integer) where {D}
     return @inbounds mat(op)[i+1, j+1]
 end
+function unsafe_getcol(op::PrimitiveBlock{D}, j::DitStr{D}) where {D}
+    # TODO: check luxury sparse implementation
+    return getcol(mat(op), j)
+end
+function getcol(op::AbstractMatrix, j::DitStr{D,N,TI}) where {D,N,TI}
+    res = op[:,buffer(j)+1]
+    if res isa SparseVector
+        return DitStr{D,N,TI}.(res.nzind .- 1), res.nzval
+    else
+        return DitStr{D,N,TI}.(0:size(op, 1)-1), res
+    end
+end
+function getcol(op::PermMatrix, j::DitStr{D,N,TI}) where {D,N,TI}
+    i = findfirst(==(buffer(j)+1), op.perm)
+    return [DitStr{D,N,TI}(i-1)], [op.vals[i]]
+end
+function getcol(op::Diagonal, j::DitStr{D,N,TI}) where {D,N,TI}
+    return [j], [op.diag[buffer(j)+1]]
+end
+function getcol(::IMatrix{T}, j::DitStr{D,N,TI}) where {D,N,TI,T}
+    return [j], [one(T)]
+end

--- a/lib/YaoBlocks/src/primitive/primitive.jl
+++ b/lib/YaoBlocks/src/primitive/primitive.jl
@@ -15,3 +15,9 @@ include("general_matrix_gate.jl")
 include("measure.jl")
 
 YaoAPI.isdiagonal(p::PrimitiveBlock) = isdiagonal(mat(p))
+
+# Certain blocks, like X block can have faster getindex, but this performance (~2ns) is probably enough!
+# Go to each block file to specialize!
+function unsafe_getindex(op::PrimitiveBlock{D}, i::Integer, j::Integer) where {D}
+    return @inbounds mat(op)[i+1, j+1]
+end

--- a/lib/YaoBlocks/src/primitive/primitive.jl
+++ b/lib/YaoBlocks/src/primitive/primitive.jl
@@ -18,12 +18,12 @@ YaoAPI.isdiagonal(p::PrimitiveBlock) = isdiagonal(mat(p))
 
 # Certain blocks, like X block can have faster getindex, but this performance (~2ns) is probably enough!
 # Go to each block file to specialize!
-function unsafe_getindex(op::PrimitiveBlock{D}, i::Integer, j::Integer) where {D}
-    return @inbounds mat(op)[i+1, j+1]
+function unsafe_getindex(::Type{T}, op::PrimitiveBlock{D}, i::Integer, j::Integer) where {T,D}
+    return @inbounds mat(T, op)[i+1, j+1]
 end
-function unsafe_getcol(op::PrimitiveBlock{D}, j::DitStr{D}) where {D}
+function unsafe_getcol(::Type{T}, op::PrimitiveBlock{D}, j::DitStr{D}) where {T,D}
     # TODO: check luxury sparse implementation
-    return getcol(mat(op), j)
+    return getcol(mat(T, op), j)
 end
 function getcol(op::AbstractMatrix, j::DitStr{D,N,TI}) where {D,N,TI}
     res = op[:,buffer(j)+1]

--- a/lib/YaoBlocks/src/primitive/primitive.jl
+++ b/lib/YaoBlocks/src/primitive/primitive.jl
@@ -22,7 +22,7 @@ function unsafe_getindex(::Type{T}, op::PrimitiveBlock{D}, i::Integer, j::Intege
     return @inbounds mat(T, op)[i+1, j+1]
 end
 function unsafe_getcol(::Type{T}, op::PrimitiveBlock{D}, j::DitStr{D}) where {T,D}
-    # TODO: check luxury sparse implementation
+    # TODO: check luxury sparse implementation of M[:,j]
     return getcol(mat(T, op), j)
 end
 function getcol(op::AbstractMatrix, j::DitStr{D,N,TI}) where {D,N,TI}

--- a/lib/YaoBlocks/src/primitive/rotation_gate.jl
+++ b/lib/YaoBlocks/src/primitive/rotation_gate.jl
@@ -133,3 +133,13 @@ cache_key(R::RotationGate) = R.theta
 iparams_range(::RotationGate{D,T,GT}) where {D,T,GT} = ((zero(T), T(2 * pi)),)
 
 occupied_locs(g::RotationGate) = occupied_locs(g.block)
+
+function unsafe_getindex(rg::RotationGate{D,T}, i::Integer, j::Integer) where {D,T}
+    return (i==j ? cos(rg.theta/2) : zero(T)) - im * sin(rg.theta/2) * unsafe_getindex(rg.block, i, j)
+end
+
+function unsafe_getindex(rg::RotationGate{D,T}, ::Colon, j::Integer) where {D,T}
+    res = im * sin(rg.theta/2) * unsafe_getindex(rg.block, :, j)
+    res[j+1] += cos(rg.theta/2)
+    return res
+end

--- a/lib/YaoBlocks/src/primitive/rotation_gate.jl
+++ b/lib/YaoBlocks/src/primitive/rotation_gate.jl
@@ -134,12 +134,13 @@ iparams_range(::RotationGate{D,T,GT}) where {D,T,GT} = ((zero(T), T(2 * pi)),)
 
 occupied_locs(g::RotationGate) = occupied_locs(g.block)
 
-function unsafe_getindex(rg::RotationGate{D,T}, i::Integer, j::Integer) where {D,T}
-    return (i==j ? cos(rg.theta/2) : zero(T)) - im * sin(rg.theta/2) * unsafe_getindex(rg.block, i, j)
+function unsafe_getindex(::Type{T}, rg::RotationGate{D}, i::Integer, j::Integer) where {D,T}
+    return (i==j ? cos(T(rg.theta)/2) : zero(T)) - im * sin(T(rg.theta)/2) * unsafe_getindex(T, rg.block, i, j)
 end
-
-function unsafe_getindex(rg::RotationGate{D,T}, ::Colon, j::Integer) where {D,T}
-    res = im * sin(rg.theta/2) * unsafe_getindex(rg.block, :, j)
-    res[j+1] += cos(rg.theta/2)
-    return res
+function unsafe_getcol(::Type{T}, rg::RotationGate{D}, j::DitStr{D}) where {D,T}
+    rows, vals = unsafe_getcol(T, rg.block, j)
+    rmul!(vals, -im * sin(T(rg.theta)/2))
+    push!(rows, j)
+    push!(vals, cos(T(rg.theta)/2))
+    return rows, vals
 end

--- a/lib/YaoBlocks/src/primitive/time_evolution.jl
+++ b/lib/YaoBlocks/src/primitive/time_evolution.jl
@@ -127,3 +127,10 @@ function YaoAPI.isunitary(te::TimeEvolution)
 end
 
 iparams_range(::TimeEvolution{D,T}) where {D,T} = ((typemin(T), typemax(T)),)
+
+function unsafe_getindex(te::TimeEvolution{D,T}, i::Integer, j::Integer) where {D,T}
+    return apply!(ArrayReg(BitBasis._onehot(Complex{T}, D^nqudits(te), j+1)), te).state[i+1]
+end
+function unsafe_getindex(te::TimeEvolution{D,T}, ::Colon, j::Integer) where {D,T}
+    return statevec(apply(ArrayReg(BitBasis._onehot(Complex{T}, D^nqudits(te), j+1)), te))
+end

--- a/lib/YaoBlocks/src/primitive/time_evolution.jl
+++ b/lib/YaoBlocks/src/primitive/time_evolution.jl
@@ -128,9 +128,12 @@ end
 
 iparams_range(::TimeEvolution{D,T}) where {D,T} = ((typemin(T), typemax(T)),)
 
-function unsafe_getindex(te::TimeEvolution{D,T}, i::Integer, j::Integer) where {D,T}
-    return apply!(ArrayReg(BitBasis._onehot(Complex{T}, D^nqudits(te), j+1)), te).state[i+1]
+function unsafe_getindex(::Type{T}, te::TimeEvolution{D}, i::Integer, j::Integer) where {D,T}
+    return apply!(ArrayReg{D}(BitBasis._onehot(T, D^nqudits(te), j+1)), te).state[i+1]
 end
-function unsafe_getcol(te::TimeEvolution{D,T}, j::DitStr{D,L,TI}) where {D,T,L,TI}
-    convert.(DitStr{D,L,TI}, basis(te)), statevec(apply(ArrayReg(BitBasis._onehot(Complex{T}, D^nqudits(te), j+1)), te))
+function unsafe_getcol(::Type{T}, te::TimeEvolution{D}, j::DitStr{D,L,TI}) where {D,T,L,TI<:Integer}
+    map(x->DitStr{D,L,TI}(buffer(x)), basis(te)), statevec(apply!(ArrayReg{D}(BitBasis.onehot(T, j)), te))
+end
+function _getindex(te::TimeEvolution{D}, ::Colon, j::EntryTable{DitStr{D,L,TI},T}) where {D,L,TI<:Integer,T}
+    EntryTable(map(x->DitStr{D,L,TI}(buffer(x)), basis(te)), YaoArrayRegister.matchtype(T, statevec(apply!(ArrayReg{D}(vec(j)), te))))
 end

--- a/lib/YaoBlocks/src/primitive/time_evolution.jl
+++ b/lib/YaoBlocks/src/primitive/time_evolution.jl
@@ -132,5 +132,5 @@ function unsafe_getindex(te::TimeEvolution{D,T}, i::Integer, j::Integer) where {
     return apply!(ArrayReg(BitBasis._onehot(Complex{T}, D^nqudits(te), j+1)), te).state[i+1]
 end
 function unsafe_getcol(te::TimeEvolution{D,T}, j::DitStr{D,L,TI}) where {D,T,L,TI}
-    convert.(Ref(DitStr{D,L,TI}), basis(te)), statevec(apply(ArrayReg(BitBasis._onehot(Complex{T}, D^nqudits(te), j+1)), te))
+    convert.(DitStr{D,L,TI}, basis(te)), statevec(apply(ArrayReg(BitBasis._onehot(Complex{T}, D^nqudits(te), j+1)), te))
 end

--- a/lib/YaoBlocks/src/primitive/time_evolution.jl
+++ b/lib/YaoBlocks/src/primitive/time_evolution.jl
@@ -131,6 +131,6 @@ iparams_range(::TimeEvolution{D,T}) where {D,T} = ((typemin(T), typemax(T)),)
 function unsafe_getindex(te::TimeEvolution{D,T}, i::Integer, j::Integer) where {D,T}
     return apply!(ArrayReg(BitBasis._onehot(Complex{T}, D^nqudits(te), j+1)), te).state[i+1]
 end
-function unsafe_getindex(te::TimeEvolution{D,T}, ::Colon, j::Integer) where {D,T}
-    return statevec(apply(ArrayReg(BitBasis._onehot(Complex{T}, D^nqudits(te), j+1)), te))
+function unsafe_getcol(te::TimeEvolution{D,T}, j::DitStr{D,L,TI}) where {D,T,L,TI}
+    convert.(Ref(DitStr{D,L,TI}), basis(te)), statevec(apply(ArrayReg(BitBasis._onehot(Complex{T}, D^nqudits(te), j+1)), te))
 end

--- a/lib/YaoBlocks/src/routines.jl
+++ b/lib/YaoBlocks/src/routines.jl
@@ -192,7 +192,7 @@ function cunmat(
 
     @inbounds colptr[1] = 1
     ctest = controller(cbits, cvals)
-    @inbounds @simd for b in basis(nbit)
+    @inbounds @simd for b in 0:1<<nbit-1
         if ctest(b)
             colptr[b+2] = colptr[b+1] + MM
         else

--- a/lib/YaoBlocks/src/treeutils/address_manipulate.jl
+++ b/lib/YaoBlocks/src/treeutils/address_manipulate.jl
@@ -104,6 +104,6 @@ function map_address(blk::Scale, info::AddressInfo)
     Scale(blk.alpha, map_address(content(blk), info))
 end
 
-function map_address(blk::Add, info::AddressInfo)
-    Add(info.nbits, map(b -> map_address(b, info), subblocks(blk)))
+function map_address(blk::AbstractAdd, info::AddressInfo)
+    chsubblocks(blk, map(b -> map_address(b, info), subblocks(blk)))
 end

--- a/lib/YaoBlocks/src/utils.jl
+++ b/lib/YaoBlocks/src/utils.jl
@@ -142,7 +142,7 @@ end
 A table of ditstring-amplitude, which can be used for e.g. indexing and operator or representing the output of operator indexing.
 
 ### Examples
-```jldoctest
+```jldoctest; setup=:(using Yao)
 julia> EntryTable([dit"121;3", dit"111;3"], [0.6, 0.8im])
 EntryTable{DitStr64{3, 3}, ComplexF64}:
   121 ₍₃₎   0.6 + 0.0im
@@ -151,7 +151,7 @@ EntryTable{DitStr64{3, 3}, ComplexF64}:
 
 The following example shows how to create a Hamiltonian and scatter this bit string by this Hamiltonian.
 
-```jldoctest
+```jldoctest; setup=:(using Yao)
 julia> b = kron(X,Z,Y)
 nqubits: 3
 kron
@@ -204,7 +204,7 @@ end
 Clean up the entry table by 1) sort entries, 2) merge items and 3) clean up zeros.
 Any value with amplitude ≤ `zero_threshold` will be regarded as zero.
 
-```jldoctest
+```jldoctest; setup=:(using Yao)
 julia> et = EntryTable([bit"000",bit"011",bit"101",bit"101",bit"011",bit"110",bit"110",bit"011",], [1.0 + 0.0im,-1, 1,1,1,-1,1,1,-1])
 EntryTable{DitStr{2, 3, Int64}, ComplexF64}:
   000 ₍₂₎   1.0 + 0.0im

--- a/lib/YaoBlocks/test/algebra.jl
+++ b/lib/YaoBlocks/test/algebra.jl
@@ -24,50 +24,6 @@ using LinearAlgebra: I
 end
 
 
-@testset "Add" begin
-    ad = Add(put(3, 2 => X), 3 * put(3, 1 => rot(Y, 0.3)), repeat(3, Z, (2, 3)))
-    @test [push!(copy(ad), put(3, 1 => X))...] |> length == 4
-    @test insert!(copy(ad), 2, put(3, 1 => X)) isa Add
-    @test append!(copy(ad), [put(3, 1 => X)]) |> length == 4
-    @test prepend!(copy(ad), [put(3, 1 => X)]) |> length == 4
-
-    @test [occupied_locs(ad)...] |> sort! == [1, 2, 3]
-    @test occupied_locs(+(put(5, 2 => X), put(5, 3 => I2))) == (2,)
-    ad2 = copy(ad)
-    @test ad2 == ad
-    push!(ad2, Toffoli)
-    @test ad2 != ad
-    @test ad2[1:end-1] == ad
-    @test ad2[end] == Toffoli
-    @test length(ad2) == 4
-    println(ad2)
-    @test cache_key(ad) != cache_key(ad2)
-    @test hash(ad) != hash(ad2)
-    ad3 = chsubblocks(ad, [put(3, 1 => X)])
-    append!(prepend!(ad3, [rot(Toffoli, 0.2)]), [control(3, 1, 2 => X)])
-    @test ad3 == Add(rot(Toffoli, 0.2), put(3, 1 => X), control(3, 1, 2 => X))
-    ad3[3] = ad3[1]
-    @test ad3 == Add(rot(Toffoli, 0.2), put(3, 1 => X), rot(Toffoli, 0.2))
-    @test ad3' == Add(rot(Toffoli, -0.2), put(3, 1 => X), rot(Toffoli, -0.2))
-
-    ad4 = similar(ad3)
-    @test typeof(ad4) == typeof(ad3)
-    @test length(ad4) == 0
-
-    reg = rand_state(3)
-    @test apply!(copy(reg), ad) ≈
-          apply!(copy(reg), ad[1]) + apply!(copy(reg), ad[2]) + apply!(copy(reg), ad[3])
-    @test mat(ad) * reg.state ≈
-          apply!(copy(reg), ad[1]) + apply!(copy(reg), ad[2]) + apply!(copy(reg), ad[3]) |>
-          state
-
-    @test Add(3) isa Add
-    @test Add(3, [put(3, 3 => X)]) isa Add
-    @test_throws QubitMismatchError Add(3, [put(10, 2 => X)])
-    @test_throws QubitMismatchError Add(put(10, 2 => X), put(4, 3 => X))
-    @test_throws QubitMismatchError apply!(rand_state(2), Add(put(10, 2 => X)))
-end
-
 @testset "block operations" begin
     r = rand_state(1)
     @test copy(r) |> X * Y * Z |> state ≈ mat(X * Y * Z) * state(r)

--- a/lib/YaoBlocks/test/algebra.jl
+++ b/lib/YaoBlocks/test/algebra.jl
@@ -86,6 +86,6 @@ end
     @test factor((2X)*(2X)) == 4
     @test factor((2X)*Y) == 2
     @test factor(X*(2Y)) == 2
-    @test 2(-X) isa Scale{Int64, 2, Scale{Val{-1}, 2, XGate}}
+    @test 2(-X) isa Scale{Int, 2, Scale{Val{-1}, 2, XGate}}
     @test mat(X^2) ≈ Matrix(I, 2, 2)
 end

--- a/lib/YaoBlocks/test/composite/add.jl
+++ b/lib/YaoBlocks/test/composite/add.jl
@@ -54,15 +54,15 @@ end
         mpb = mat(pb)
         allpass = true
         for i=basis(pb), j=basis(pb)
-            allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
+            allpass &= pb[i, j] ≈ mpb[Int(i)+1, Int(j)+1]
         end
         @test allpass
         allpass = true
         for j=basis(pb)
-            allpass &= vec(pb[:, j]) == mpb[:, Int(j)+1]
-            allpass &= vec(pb[j,:]) == mpb[Int(j)+1,:]
-            allpass &= vec(pb[:, EntryTable([j], [1.0+0im])]) == mpb[:, Int(j)+1]
-            allpass &= vec(pb[EntryTable([j], [1.0+0im]),:]) == mpb[Int(j)+1,:]
+            allpass &= vec(pb[:, j]) ≈ mpb[:, Int(j)+1]
+            allpass &= vec(pb[j,:]) ≈ mpb[Int(j)+1,:]
+            allpass &= vec(pb[:, EntryTable([j], [1.0+0im])]) ≈ mpb[:, Int(j)+1]
+            allpass &= vec(pb[EntryTable([j], [1.0+0im]),:]) ≈ mpb[Int(j)+1,:]
         end
         @test allpass
     end

--- a/lib/YaoBlocks/test/composite/add.jl
+++ b/lib/YaoBlocks/test/composite/add.jl
@@ -48,18 +48,19 @@ using LinearAlgebra: I
 end
 
 @testset "getindex2" begin
-    pb = put(3, 3=>Y) + control(3, (2,), 1=>X)
-    mpb = mat(pb)
-    allpass = true
-    for i=basis(pb), j=basis(pb)
-        allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
+    for pb in [put(3, 3=>Y) + control(3, (2,), 1=>X),
+                put(5, 2=>Y) + control(5, (2,), (4,3)=>matblock(rand_unitary(4)))
+                ]
+        mpb = mat(pb)
+        allpass = true
+        for i=basis(pb), j=basis(pb)
+            allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
+        end
+        @test allpass
+        allpass = true
+        for j=basis(pb)
+            allpass &= vec(pb[:, j]) == mpb[:, Int(j)+1]
+        end
+        @test allpass
     end
-    @test allpass
-    pb = put(5, 2=>Y) + control(5, (2,), (4,3)=>matblock(rand_unitary(4)))
-    mpb = mat(pb)
-    allpass = true
-    for i=basis(pb), j=basis(pb)
-        allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
-    end
-    @test allpass
 end

--- a/lib/YaoBlocks/test/composite/add.jl
+++ b/lib/YaoBlocks/test/composite/add.jl
@@ -47,7 +47,7 @@ using LinearAlgebra: I
     @test_throws QubitMismatchError apply!(rand_state(2), Add(put(10, 2 => X)))
 end
 
-@testset "getindex2" begin
+@testset "instruct_get_element" begin
     for pb in [put(3, 3=>Y) + control(3, (2,), 1=>X),
                 put(5, 2=>Y) + control(5, (2,), (4,3)=>matblock(rand_unitary(4)))
                 ]

--- a/lib/YaoBlocks/test/composite/add.jl
+++ b/lib/YaoBlocks/test/composite/add.jl
@@ -62,6 +62,7 @@ end
             allpass &= vec(pb[:, j]) == mpb[:, Int(j)+1]
             allpass &= vec(pb[j,:]) == mpb[Int(j)+1,:]
             allpass &= vec(pb[:, EntryTable([j], [1.0+0im])]) == mpb[:, Int(j)+1]
+            allpass &= vec(pb[EntryTable([j], [1.0+0im]),:]) == mpb[Int(j)+1,:]
         end
         @test allpass
     end

--- a/lib/YaoBlocks/test/composite/add.jl
+++ b/lib/YaoBlocks/test/composite/add.jl
@@ -60,6 +60,8 @@ end
         allpass = true
         for j=basis(pb)
             allpass &= vec(pb[:, j]) == mpb[:, Int(j)+1]
+            allpass &= vec(pb[j,:]) == mpb[Int(j)+1,:]
+            allpass &= vec(pb[:, EntryTable([j], [1.0+0im])]) == mpb[:, Int(j)+1]
         end
         @test allpass
     end

--- a/lib/YaoBlocks/test/composite/add.jl
+++ b/lib/YaoBlocks/test/composite/add.jl
@@ -1,0 +1,65 @@
+using Test, YaoBlocks, YaoArrayRegister
+import YaoBlocks.ConstGate: Toffoli
+using YaoAPI: QubitMismatchError
+using LinearAlgebra: I
+
+@testset "Add" begin
+    ad = Add(put(3, 2 => X), 3 * put(3, 1 => rot(Y, 0.3)), repeat(3, Z, (2, 3)))
+    @test [push!(copy(ad), put(3, 1 => X))...] |> length == 4
+    @test insert!(copy(ad), 2, put(3, 1 => X)) isa Add
+    @test append!(copy(ad), [put(3, 1 => X)]) |> length == 4
+    @test prepend!(copy(ad), [put(3, 1 => X)]) |> length == 4
+
+    @test [occupied_locs(ad)...] |> sort! == [1, 2, 3]
+    @test occupied_locs(+(put(5, 2 => X), put(5, 3 => I2))) == (2,)
+    ad2 = copy(ad)
+    @test ad2 == ad
+    push!(ad2, Toffoli)
+    @test ad2 != ad
+    @test ad2[1:end-1] == ad
+    @test ad2[end] == Toffoli
+    @test length(ad2) == 4
+    println(ad2)
+    @test cache_key(ad) != cache_key(ad2)
+    @test hash(ad) != hash(ad2)
+    ad3 = chsubblocks(ad, [put(3, 1 => X)])
+    append!(prepend!(ad3, [rot(Toffoli, 0.2)]), [control(3, 1, 2 => X)])
+    @test ad3 == Add(rot(Toffoli, 0.2), put(3, 1 => X), control(3, 1, 2 => X))
+    ad3[3] = ad3[1]
+    @test ad3 == Add(rot(Toffoli, 0.2), put(3, 1 => X), rot(Toffoli, 0.2))
+    @test ad3' == Add(rot(Toffoli, -0.2), put(3, 1 => X), rot(Toffoli, -0.2))
+
+    ad4 = similar(ad3)
+    @test typeof(ad4) == typeof(ad3)
+    @test length(ad4) == 0
+
+    reg = rand_state(3)
+    @test apply!(copy(reg), ad) ≈
+          apply!(copy(reg), ad[1]) + apply!(copy(reg), ad[2]) + apply!(copy(reg), ad[3])
+    @test mat(ad) * reg.state ≈
+          apply!(copy(reg), ad[1]) + apply!(copy(reg), ad[2]) + apply!(copy(reg), ad[3]) |>
+          state
+
+    @test Add(3) isa Add
+    @test Add(3, [put(3, 3 => X)]) isa Add
+    @test_throws QubitMismatchError Add(3, [put(10, 2 => X)])
+    @test_throws QubitMismatchError Add(put(10, 2 => X), put(4, 3 => X))
+    @test_throws QubitMismatchError apply!(rand_state(2), Add(put(10, 2 => X)))
+end
+
+@testset "getindex2" begin
+    pb = put(3, 3=>Y) + control(3, (2,), 1=>X)
+    mpb = mat(pb)
+    allpass = true
+    for i=basis(pb), j=basis(pb)
+        allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
+    end
+    @test allpass
+    pb = put(5, 2=>Y) + control(5, (2,), (4,3)=>matblock(rand_unitary(4)))
+    mpb = mat(pb)
+    allpass = true
+    for i=basis(pb), j=basis(pb)
+        allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
+    end
+    @test allpass
+end

--- a/lib/YaoBlocks/test/composite/cache.jl
+++ b/lib/YaoBlocks/test/composite/cache.jl
@@ -96,6 +96,7 @@ end
             allpass &= vec(pb[:, j]) == mpb[:, Int(j)+1]
             allpass &= vec(pb[:, EntryTable([j], [1.0+0im])]) == mpb[:, Int(j)+1]
             allpass &= vec(pb[j,:]) == mpb[Int(j)+1,:]
+            allpass &= vec(pb[EntryTable([j], [1.0+0im]),:]) == mpb[Int(j)+1,:]
         end
         @test allpass
     end

--- a/lib/YaoBlocks/test/composite/cache.jl
+++ b/lib/YaoBlocks/test/composite/cache.jl
@@ -83,7 +83,7 @@ end
     @test pull(C) ≈ mat(C)
 end
 
-@testset "getindex2" begin
+@testset "instruct_get_element" begin
     for pb in [put(3, 2=>Y) |> cache, put(4, (4,2)=>matblock(rand_unitary(9); nlevel=3)) |> cache]
         mpb = mat(pb)
         allpass = true

--- a/lib/YaoBlocks/test/composite/cache.jl
+++ b/lib/YaoBlocks/test/composite/cache.jl
@@ -84,18 +84,17 @@ end
 end
 
 @testset "getindex2" begin
-    pb = put(3, 2=>Y) |> cache
-    mpb = mat(pb)
-    allpass = true
-    for i=basis(pb), j=basis(pb)
-        allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
+    for pb in [put(3, 2=>Y) |> cache, put(4, (4,2)=>matblock(rand_unitary(9); nlevel=3)) |> cache]
+        mpb = mat(pb)
+        allpass = true
+        for i=basis(pb), j=basis(pb)
+            allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
+        end
+        @test allpass
+        allpass = true
+        for j=basis(pb)
+            allpass &= vec(pb[:, j]) == mpb[:, Int(j)+1]
+        end
+        @test allpass
     end
-    @test allpass
-    pb = put(4, (4,2)=>matblock(rand_unitary(9); nlevel=3)) |> cache
-    mpb = mat(pb)
-    allpass = true
-    for i=basis(pb), j=basis(pb)
-        allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
-    end
-    @test allpass
 end

--- a/lib/YaoBlocks/test/composite/cache.jl
+++ b/lib/YaoBlocks/test/composite/cache.jl
@@ -82,3 +82,20 @@ end
     update_cache(ComplexF64, C)
     @test pull(C) ≈ mat(C)
 end
+
+@testset "getindex2" begin
+    pb = put(3, 2=>Y) |> cache
+    mpb = mat(pb)
+    allpass = true
+    for i=basis(pb), j=basis(pb)
+        allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
+    end
+    @test allpass
+    pb = put(4, (4,2)=>matblock(rand_unitary(9); nlevel=3)) |> cache
+    mpb = mat(pb)
+    allpass = true
+    for i=basis(pb), j=basis(pb)
+        allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
+    end
+    @test allpass
+end

--- a/lib/YaoBlocks/test/composite/cache.jl
+++ b/lib/YaoBlocks/test/composite/cache.jl
@@ -94,6 +94,8 @@ end
         allpass = true
         for j=basis(pb)
             allpass &= vec(pb[:, j]) == mpb[:, Int(j)+1]
+            allpass &= vec(pb[:, EntryTable([j], [1.0+0im])]) == mpb[:, Int(j)+1]
+            allpass &= vec(pb[j,:]) == mpb[Int(j)+1,:]
         end
         @test allpass
     end

--- a/lib/YaoBlocks/test/composite/chain.jl
+++ b/lib/YaoBlocks/test/composite/chain.jl
@@ -180,26 +180,20 @@ end
 end
 
 @testset "getindex2" begin
-    pb = chain(3)
-    mpb = mat(pb)
-    allpass = true
-    for i=basis(pb), j=basis(pb)
-        allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
+    for pb in [chain(3), chain(put(3, 2=>Y)),
+        chain(put(4, (4,2)=>matblock(rand_unitary(9); nlevel=3)), put(4, (3,)=>matblock(rand_unitary(3); nlevel=3)))
+    ]
+        mpb = mat(pb)
+        allpass = true
+        for i=basis(pb), j=basis(pb)
+            allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
+        end
+        @test allpass
+        allpass = true
+        for j=basis(pb)
+            allpass &= vec(pb[:, j]) == mpb[:, Int(j)+1]
+            allpass &= vec(pb[j,:]) == mpb[Int(j)+1,:]
+        end
+        @test allpass
     end
-    @test allpass
- 
-    pb = chain(put(3, 2=>Y))
-    mpb = mat(pb)
-    allpass = true
-    for i=basis(pb), j=basis(pb)
-        allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
-    end
-    @test allpass
-    pb = chain(put(4, (4,2)=>matblock(rand_unitary(9); nlevel=3)), put(4, (3,)=>matblock(rand_unitary(3); nlevel=3)))
-    mpb = mat(pb)
-    allpass = true
-    for i=basis(pb), j=basis(pb)
-        allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
-    end
-    @test allpass
 end

--- a/lib/YaoBlocks/test/composite/chain.jl
+++ b/lib/YaoBlocks/test/composite/chain.jl
@@ -192,6 +192,7 @@ end
         allpass = true
         for j=basis(pb)
             allpass &= vec(pb[:, j]) == mpb[:, Int(j)+1]
+            allpass &= vec(pb[:, EntryTable([j], [1.0+0im])]) == mpb[:, Int(j)+1]
             allpass &= vec(pb[j,:]) == mpb[Int(j)+1,:]
         end
         @test allpass

--- a/lib/YaoBlocks/test/composite/chain.jl
+++ b/lib/YaoBlocks/test/composite/chain.jl
@@ -179,7 +179,7 @@ end
     @test mat(chain(2)) == IMatrix{4,ComplexF64}()
 end
 
-@testset "getindex2" begin
+@testset "instruct_get_element" begin
     for pb in [chain(3), chain(put(3, 2=>Y)),
         chain(put(4, (4,2)=>matblock(rand_unitary(9); nlevel=3)), put(4, (3,)=>matblock(rand_unitary(3); nlevel=3)))
     ]

--- a/lib/YaoBlocks/test/composite/chain.jl
+++ b/lib/YaoBlocks/test/composite/chain.jl
@@ -178,3 +178,28 @@ end
 @testset "Yao/#204" begin
     @test mat(chain(2)) == IMatrix{4,ComplexF64}()
 end
+
+@testset "getindex2" begin
+    pb = chain(3)
+    mpb = mat(pb)
+    allpass = true
+    for i=basis(pb), j=basis(pb)
+        allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
+    end
+    @test allpass
+ 
+    pb = chain(put(3, 2=>Y))
+    mpb = mat(pb)
+    allpass = true
+    for i=basis(pb), j=basis(pb)
+        allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
+    end
+    @test allpass
+    pb = chain(put(4, (4,2)=>matblock(rand_unitary(9); nlevel=3)), put(4, (3,)=>matblock(rand_unitary(3); nlevel=3)))
+    mpb = mat(pb)
+    allpass = true
+    for i=basis(pb), j=basis(pb)
+        allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
+    end
+    @test allpass
+end

--- a/lib/YaoBlocks/test/composite/chain.jl
+++ b/lib/YaoBlocks/test/composite/chain.jl
@@ -194,6 +194,7 @@ end
             allpass &= vec(pb[:, j]) == mpb[:, Int(j)+1]
             allpass &= vec(pb[:, EntryTable([j], [1.0+0im])]) == mpb[:, Int(j)+1]
             allpass &= vec(pb[j,:]) == mpb[Int(j)+1,:]
+            allpass &= vec(pb[EntryTable([j], [1.0+0im]),:]) == mpb[Int(j)+1,:]
         end
         @test allpass
     end

--- a/lib/YaoBlocks/test/composite/composite.jl
+++ b/lib/YaoBlocks/test/composite/composite.jl
@@ -4,6 +4,10 @@ using Test, YaoAPI, YaoBlocks, YaoArrayRegister
     include("chain.jl")
 end
 
+@testset "test add" begin
+    include("add.jl")
+end
+
 @testset "test kron" begin
     include("kron.jl")
 end

--- a/lib/YaoBlocks/test/composite/control.jl
+++ b/lib/YaoBlocks/test/composite/control.jl
@@ -114,6 +114,7 @@ end
         allpass = true
         for j=basis(pb)
             allpass &= vec(pb[:, j]) == mpb[:, Int(j)+1]
+            allpass &= vec(pb[j, :]) == mpb[Int(j)+1, :]
         end
         @test allpass
     end

--- a/lib/YaoBlocks/test/composite/control.jl
+++ b/lib/YaoBlocks/test/composite/control.jl
@@ -104,18 +104,17 @@ end
 end
 
 @testset "getindex2" begin
-    pb = control(3, 2, 1=>Y)
-    mpb = mat(pb)
-    allpass = true
-    for i=basis(pb), j=basis(pb)
-        allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
+    for pb in [control(3, 2, 1=>Y), control(4, 3, (4,2)=>matblock(rand_unitary(4)))]
+        mpb = mat(pb)
+        allpass = true
+        for i=basis(pb), j=basis(pb)
+            allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
+        end
+        @test allpass
+        allpass = true
+        for j=basis(pb)
+            allpass &= vec(pb[:, j]) == mpb[:, Int(j)+1]
+        end
+        @test allpass
     end
-    @test allpass
-    pb = control(4, 3, (4,2)=>matblock(rand_unitary(4)))
-    mpb = mat(pb)
-    allpass = true
-    for i=basis(pb), j=basis(pb)
-        allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
-    end
-    @test allpass
 end

--- a/lib/YaoBlocks/test/composite/control.jl
+++ b/lib/YaoBlocks/test/composite/control.jl
@@ -86,7 +86,7 @@ end
     @test applymatrix(g) ≈ mat(Toffoli) |> invorder
     @test occupied_locs(g) == (3, 2, 1)
     g = ControlBlock(3, (2,), CNOT, (3, 1))
-    g2 = PutBlock(3, Toffoli, (2, 3, 1))
+    g2 = PutBlock(3, Toffoli, (3, 2, 1))
     g3 = ControlBlock(3, (3, 2), X, (1,))
     @test applymatrix(g) == applymatrix(g2) == applymatrix(g3)
     @test mat(g) == mat(g2)

--- a/lib/YaoBlocks/test/composite/control.jl
+++ b/lib/YaoBlocks/test/composite/control.jl
@@ -103,7 +103,7 @@ end
     @test copy(c) == c
 end
 
-@testset "getindex2" begin
+@testset "instruct_get_element" begin
     for pb in [control(3, 2, 1=>Y), control(4, 3, (4,2)=>matblock(rand_unitary(4)))]
         mpb = mat(pb)
         allpass = true

--- a/lib/YaoBlocks/test/composite/control.jl
+++ b/lib/YaoBlocks/test/composite/control.jl
@@ -102,3 +102,20 @@ end
     @test c == control(5, (2,3), 1=>X)
     @test copy(c) == c
 end
+
+@testset "getindex2" begin
+    pb = control(3, 2, 1=>Y)
+    mpb = mat(pb)
+    allpass = true
+    for i=basis(pb), j=basis(pb)
+        allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
+    end
+    @test allpass
+    pb = control(4, 3, (4,2)=>matblock(rand_unitary(4)))
+    mpb = mat(pb)
+    allpass = true
+    for i=basis(pb), j=basis(pb)
+        allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
+    end
+    @test allpass
+end

--- a/lib/YaoBlocks/test/composite/kron.jl
+++ b/lib/YaoBlocks/test/composite/kron.jl
@@ -123,7 +123,7 @@ end
     @test mat(T, kron(5)) === mat(T, chain(5)) == IMatrix{1 << 5,Float64}()
 end
 
-@testset "getindex2" begin
+@testset "instruct_get_element" begin
     for pb in [kron(3), kron(3, 2=>Y, 3=>X),
             kron(6, 2:3=>matblock(rand_unitary(9); nlevel=3), 1=>matblock(rand_unitary(3); nlevel=3), 5=>matblock(rand_unitary(3); nlevel=3))]
         mpb = mat(pb)

--- a/lib/YaoBlocks/test/composite/kron.jl
+++ b/lib/YaoBlocks/test/composite/kron.jl
@@ -124,6 +124,14 @@ end
 end
 
 @testset "getindex2" begin
+    pb = kron(3, 2=>Y, 3=>X)
+    mpb = mat(pb)
+    allpass = true
+    for i=basis(pb), j=basis(pb)
+        allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
+    end
+    @test allpass
+ 
     pb = kron(5, 2=>Y, 3=>X)
     mpb = mat(pb)
     allpass = true
@@ -131,7 +139,7 @@ end
         allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
     end
     @test allpass
-    pb = kron(5, 2:3=>matblock(rand_unitary(4)), 4=>X)
+    pb = kron(4, 2:3=>matblock(rand_unitary(9); nlevel=3), 1=>matblock(rand_unitary(3); nlevel=3))
     mpb = mat(pb)
     allpass = true
     for i=basis(pb), j=basis(pb)

--- a/lib/YaoBlocks/test/composite/kron.jl
+++ b/lib/YaoBlocks/test/composite/kron.jl
@@ -132,6 +132,14 @@ end
     end
     @test allpass
  
+    pb = kron(3, 2=>Y, 3=>X)
+    mpb = mat(pb)
+    allpass = true
+    for j=basis(pb)
+        allpass &= vec(pb[:, j]) == mpb[:, Int(j)+1]
+    end
+    @test allpass
+ 
     pb = kron(5, 2=>Y, 3=>X)
     mpb = mat(pb)
     allpass = true
@@ -144,6 +152,14 @@ end
     allpass = true
     for i=basis(pb), j=basis(pb)
         allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
+    end
+    @test allpass
+
+    pb = kron(6, 2:3=>matblock(rand_unitary(9); nlevel=3), 1=>matblock(rand_unitary(3); nlevel=3), 5=>matblock(rand_unitary(3); nlevel=3))
+    mpb = mat(pb)
+    allpass = true
+    for j=basis(pb)
+        allpass &= vec(pb[:, j]) == mpb[:, Int(j)+1]
     end
     @test allpass
 end

--- a/lib/YaoBlocks/test/composite/kron.jl
+++ b/lib/YaoBlocks/test/composite/kron.jl
@@ -122,3 +122,20 @@ end
     T = Float64
     @test mat(T, kron(5)) === mat(T, chain(5)) == IMatrix{1 << 5,Float64}()
 end
+
+@testset "getindex2" begin
+    pb = kron(5, 2=>Y, 3=>X)
+    mpb = mat(pb)
+    allpass = true
+    for i=basis(pb), j=basis(pb)
+        allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
+    end
+    @test allpass
+    pb = kron(5, 2:3=>matblock(rand_unitary(4)), 4=>X)
+    mpb = mat(pb)
+    allpass = true
+    for i=basis(pb), j=basis(pb)
+        allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
+    end
+    @test allpass
+end

--- a/lib/YaoBlocks/test/composite/kron.jl
+++ b/lib/YaoBlocks/test/composite/kron.jl
@@ -136,6 +136,8 @@ end
         allpass = true
         for j=basis(pb)
             allpass &= vec(pb[:, j]) ≈ mpb[:, Int(j)+1]
+            allpass &= vec(pb[:, EntryTable([j], [1.0+0im])]) == mpb[:, Int(j)+1]
+            allpass &= vec(pb[j,:]) ≈ mpb[Int(j)+1,:]
         end
         @test allpass
     end

--- a/lib/YaoBlocks/test/composite/kron.jl
+++ b/lib/YaoBlocks/test/composite/kron.jl
@@ -124,42 +124,19 @@ end
 end
 
 @testset "getindex2" begin
-    pb = kron(3, 2=>Y, 3=>X)
-    mpb = mat(pb)
-    allpass = true
-    for i=basis(pb), j=basis(pb)
-        allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
-    end
-    @test allpass
- 
-    pb = kron(3, 2=>Y, 3=>X)
-    mpb = mat(pb)
-    allpass = true
-    for j=basis(pb)
-        allpass &= vec(pb[:, j]) == mpb[:, Int(j)+1]
-    end
-    @test allpass
- 
-    pb = kron(5, 2=>Y, 3=>X)
-    mpb = mat(pb)
-    allpass = true
-    for i=basis(pb), j=basis(pb)
-        allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
-    end
-    @test allpass
-    pb = kron(4, 2:3=>matblock(rand_unitary(9); nlevel=3), 1=>matblock(rand_unitary(3); nlevel=3))
-    mpb = mat(pb)
-    allpass = true
-    for i=basis(pb), j=basis(pb)
-        allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
-    end
-    @test allpass
+    for pb in [kron(3), kron(3, 2=>Y, 3=>X),
+            kron(6, 2:3=>matblock(rand_unitary(9); nlevel=3), 1=>matblock(rand_unitary(3); nlevel=3), 5=>matblock(rand_unitary(3); nlevel=3))]
+        mpb = mat(pb)
+        allpass = true
+        for i=basis(pb), j=basis(pb)
+            allpass &= pb[i, j] ≈ mpb[Int(i)+1, Int(j)+1]
+        end
+        @test allpass
 
-    pb = kron(6, 2:3=>matblock(rand_unitary(9); nlevel=3), 1=>matblock(rand_unitary(3); nlevel=3), 5=>matblock(rand_unitary(3); nlevel=3))
-    mpb = mat(pb)
-    allpass = true
-    for j=basis(pb)
-        allpass &= vec(pb[:, j]) == mpb[:, Int(j)+1]
+        allpass = true
+        for j=basis(pb)
+            allpass &= vec(pb[:, j]) ≈ mpb[:, Int(j)+1]
+        end
+        @test allpass
     end
-    @test allpass
 end

--- a/lib/YaoBlocks/test/composite/put.jl
+++ b/lib/YaoBlocks/test/composite/put.jl
@@ -1,5 +1,7 @@
 using Test, YaoBlocks, YaoArrayRegister
 using YaoBlocks.ConstGate
+using SparseArrays
+using LinearAlgebra
 
 @testset "construct" begin
     @test_throws AssertionError put(2, 1 => swap(2, 1, 2))
@@ -55,4 +57,35 @@ end
           mat(put(5, 2 => Ry(0.3))) * reg.state
     @test apply!(copy(reg), put(5, 2 => Rz(0.3))) |> state ≈
           mat(put(5, 2 => Rz(0.3))) * reg.state
+end
+
+@testset "operators" begin
+    @test size(mat(put(2,1=>matblock(rand_unitary(3))))) == (9, 9)
+    @test size(mat(repeat(2,matblock(rand_unitary(3))))) == (9, 9)
+end
+
+@testset "put matrix" begin
+    u = sparse(randn(ComplexF64, 2, 2))
+    m1 = mat(put(10, (4,)=>matblock(u)))
+    m2 = invoke(YaoBlocks.unmat, Tuple{Val,Int,AbstractMatrix,NTuple}, Val{2}(), 10, u, (4,))
+    @test m1 ≈ m2
+
+    u = sparse(randn(ComplexF64, 4, 4))
+    m1 = mat(put(10, (2,4)=>matblock(u)))
+    m2 = invoke(YaoBlocks.unmat, Tuple{Val,Int,AbstractMatrix,NTuple}, Val{2}(), 10, u, (2,4))
+    @test nnz(m1) == nnz(m2)
+    @test m1 ≈ m2
+
+    u = randn(ComplexF64, 8, 8)
+    m1 = mat(put(10, (4,2,9)=>matblock(u)))
+    m2 = invoke(YaoBlocks.unmat, Tuple{Val,Int,AbstractMatrix,NTuple}, Val{2}(), 10, u, (4,2,9))
+    @test m1 ≈ m2
+
+    RP1 = matblock(rand_unitary(3); nlevel=3)
+    RNr = matblock(rand_unitary(3); nlevel=3)
+    @test mat(put(5, 2=>RP1)) ≈ kron(Matrix(I,27,27), mat(RP1), Matrix(I, 3,3))
+    @test mat(put(5, (2,3)=>kron(RNr,RP1))) ≈ kron(Matrix(I,9,9), mat(RP1), mat(RNr), Matrix(I, 3,3))
+
+    # corner case, single qubit gate
+    @test mat(put(1, 1=>RP1)) ≈ mat(RP1)
 end

--- a/lib/YaoBlocks/test/composite/put.jl
+++ b/lib/YaoBlocks/test/composite/put.jl
@@ -89,3 +89,20 @@ end
     # corner case, single qubit gate
     @test mat(put(1, 1=>RP1)) ≈ mat(RP1)
 end
+
+@testset "getindex2" begin
+    pb = put(3, 2=>Y)
+    mpb = mat(pb)
+    allpass = true
+    for i=basis(pb), j=basis(pb)
+        allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
+    end
+    @test allpass
+    pb = put(4, (4,2)=>matblock(rand_unitary(4)))
+    mpb = mat(pb)
+    allpass = true
+    for i=basis(pb), j=basis(pb)
+        allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
+    end
+    @test allpass
+end

--- a/lib/YaoBlocks/test/composite/put.jl
+++ b/lib/YaoBlocks/test/composite/put.jl
@@ -90,7 +90,7 @@ end
     @test mat(put(1, 1=>RP1)) ≈ mat(RP1)
 end
 
-@testset "getindex2" begin
+@testset "instruct_get_element" begin
     for pb in [put(3, 2=>Y), put(4, (4,2)=>matblock(rand_unitary(9); nlevel=3))]
         mpb = mat(pb)
         allpass = true

--- a/lib/YaoBlocks/test/composite/put.jl
+++ b/lib/YaoBlocks/test/composite/put.jl
@@ -104,6 +104,7 @@ end
             allpass &= vec(pb[:, j]) == mpb[:, Int(j)+1]
             allpass &= vec(pb[:, EntryTable([j], [1.0+0im])]) == mpb[:, Int(j)+1]
             allpass &= vec(pb[j,:]) == mpb[Int(j)+1,:]
+            allpass &= vec(pb[EntryTable([j], [1.0+0im]),:]) == mpb[Int(j)+1,:]
         end
         @test allpass
     end

--- a/lib/YaoBlocks/test/composite/put.jl
+++ b/lib/YaoBlocks/test/composite/put.jl
@@ -98,7 +98,7 @@ end
         allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
     end
     @test allpass
-    pb = put(4, (4,2)=>matblock(rand_unitary(4)))
+    pb = put(4, (4,2)=>matblock(rand_unitary(9); nlevel=3))
     mpb = mat(pb)
     allpass = true
     for i=basis(pb), j=basis(pb)

--- a/lib/YaoBlocks/test/composite/put.jl
+++ b/lib/YaoBlocks/test/composite/put.jl
@@ -60,8 +60,8 @@ end
 end
 
 @testset "operators" begin
-    @test size(mat(put(2,1=>matblock(rand_unitary(3))))) == (9, 9)
-    @test size(mat(repeat(2,matblock(rand_unitary(3))))) == (9, 9)
+    @test size(mat(put(2,1=>matblock(rand_unitary(3); nlevel=3)))) == (9, 9)
+    @test size(mat(repeat(2,matblock(rand_unitary(3); nlevel=3)))) == (9, 9)
 end
 
 @testset "put matrix" begin

--- a/lib/YaoBlocks/test/composite/put.jl
+++ b/lib/YaoBlocks/test/composite/put.jl
@@ -98,22 +98,13 @@ end
             allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
         end
         @test allpass
-    end
 
-    # col
-    pb = put(4, (1,4)=>matblock(rand_unitary(4)))
-    mpb = mat(pb)
-    allpass = true
-    for j=basis(pb)
-        allpass &= vec(pb[:, j]) == mpb[:, Int(j)+1]
+        allpass = true
+        for j=basis(pb)
+            allpass &= vec(pb[:, j]) == mpb[:, Int(j)+1]
+            allpass &= vec(pb[:, EntryTable([j], [1.0+0im])]) == mpb[:, Int(j)+1]
+            allpass &= vec(pb[j,:]) == mpb[Int(j)+1,:]
+        end
+        @test allpass
     end
-    @test allpass
-
-    pb = put(4, (4,2)=>matblock(rand_unitary(9); nlevel=3))
-    mpb = mat(pb)
-    allpass = true
-    for j=basis(pb)
-        allpass &= sparse(pb[:, j]) ≈ sparse(mpb[:, Int(j)+1])
-    end
-    @test allpass
 end

--- a/lib/YaoBlocks/test/composite/put.jl
+++ b/lib/YaoBlocks/test/composite/put.jl
@@ -98,11 +98,29 @@ end
         allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
     end
     @test allpass
+
+    # col
+    pb = put(4, (1,4)=>matblock(rand_unitary(4)))
+    mpb = mat(pb)
+    allpass = true
+    for j=basis(pb)
+        allpass &= vec(pb[:, j]) == mpb[:, Int(j)+1]
+    end
+    @test allpass
+
     pb = put(4, (4,2)=>matblock(rand_unitary(9); nlevel=3))
     mpb = mat(pb)
     allpass = true
     for i=basis(pb), j=basis(pb)
         allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
+    end
+    @test allpass
+
+    pb = put(4, (4,2)=>matblock(rand_unitary(9); nlevel=3))
+    mpb = mat(pb)
+    allpass = true
+    for j=basis(pb)
+        allpass &= sparse(pb[:, j]) ≈ sparse(mpb[:, Int(j)+1])
     end
     @test allpass
 end

--- a/lib/YaoBlocks/test/composite/put.jl
+++ b/lib/YaoBlocks/test/composite/put.jl
@@ -91,13 +91,14 @@ end
 end
 
 @testset "getindex2" begin
-    pb = put(3, 2=>Y)
-    mpb = mat(pb)
-    allpass = true
-    for i=basis(pb), j=basis(pb)
-        allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
+    for pb in [put(3, 2=>Y), put(4, (4,2)=>matblock(rand_unitary(9); nlevel=3))]
+        mpb = mat(pb)
+        allpass = true
+        for i=basis(pb), j=basis(pb)
+            allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
+        end
+        @test allpass
     end
-    @test allpass
 
     # col
     pb = put(4, (1,4)=>matblock(rand_unitary(4)))
@@ -105,14 +106,6 @@ end
     allpass = true
     for j=basis(pb)
         allpass &= vec(pb[:, j]) == mpb[:, Int(j)+1]
-    end
-    @test allpass
-
-    pb = put(4, (4,2)=>matblock(rand_unitary(9); nlevel=3))
-    mpb = mat(pb)
-    allpass = true
-    for i=basis(pb), j=basis(pb)
-        allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
     end
     @test allpass
 

--- a/lib/YaoBlocks/test/composite/repeated.jl
+++ b/lib/YaoBlocks/test/composite/repeated.jl
@@ -46,4 +46,10 @@ end
         allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
     end
     @test allpass
+
+    allpass = true
+    for j=basis(pb)
+        allpass &= vec(pb[:, j]) == mpb[:, Int(j)+1]
+    end
+    @test allpass
 end

--- a/lib/YaoBlocks/test/composite/repeated.jl
+++ b/lib/YaoBlocks/test/composite/repeated.jl
@@ -31,7 +31,7 @@ using LuxurySparse
     @test mat(repeat(10, X, ())) == IMatrix{1<<10}()
 end
 
-@testset "getindex2" begin
+@testset "instruct_get_element" begin
     for pb in [repeat(3, Y, (3,2)), repeat(5, matblock(rand_unitary(3); nlevel=3), (5, 2))]
         mpb = mat(pb)
         allpass = true

--- a/lib/YaoBlocks/test/composite/repeated.jl
+++ b/lib/YaoBlocks/test/composite/repeated.jl
@@ -32,24 +32,20 @@ using LuxurySparse
 end
 
 @testset "getindex2" begin
-    pb = repeat(3, Y, (3,2))
-    mpb = mat(pb)
-    allpass = true
-    for i=basis(pb), j=basis(pb)
-        allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
-    end
-    @test allpass
-    pb = repeat(5, matblock(rand_unitary(3); nlevel=3), (5, 2))
-    mpb = mat(pb)
-    allpass = true
-    for i=basis(pb), j=basis(pb)
-        allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
-    end
-    @test allpass
+    for pb in [repeat(3, Y, (3,2)), repeat(5, matblock(rand_unitary(3); nlevel=3), (5, 2))]
+        mpb = mat(pb)
+        allpass = true
+        for i=basis(pb), j=basis(pb)
+            allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
+        end
+        @test allpass
 
-    allpass = true
-    for j=basis(pb)
-        allpass &= vec(pb[:, j]) == mpb[:, Int(j)+1]
+        allpass = true
+        for j=basis(pb)
+            allpass &= vec(pb[:, j]) == mpb[:, Int(j)+1]
+            allpass &= vec(pb[:, EntryTable([j], [1.0+0im])]) == mpb[:, Int(j)+1]
+            allpass &= vec(pb[j, :]) == mpb[Int(j)+1, :]
+        end
+        @test allpass
     end
-    @test allpass
 end

--- a/lib/YaoBlocks/test/composite/repeated.jl
+++ b/lib/YaoBlocks/test/composite/repeated.jl
@@ -30,3 +30,20 @@ using LuxurySparse
 
     @test mat(repeat(10, X, ())) == IMatrix{1<<10}()
 end
+
+@testset "getindex2" begin
+    pb = repeat(3, Y, (3,2))
+    mpb = mat(pb)
+    allpass = true
+    for i=basis(pb), j=basis(pb)
+        allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
+    end
+    @test allpass
+    pb = repeat(5, matblock(rand_unitary(3); nlevel=3), (5, 2))
+    mpb = mat(pb)
+    allpass = true
+    for i=basis(pb), j=basis(pb)
+        allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
+    end
+    @test allpass
+end

--- a/lib/YaoBlocks/test/composite/subroutine.jl
+++ b/lib/YaoBlocks/test/composite/subroutine.jl
@@ -43,3 +43,20 @@ end
     @test_throws ErrorException subroutine(5, put(3,2=>X), (7,4,5))
     @test YaoBlocks.PropertyTrait(s) == YaoBlocks.PreserveAll()
 end
+
+@testset "getindex2" begin
+    pb = subroutine(3, Y, (2,))
+    mpb = mat(pb)
+    allpass = true
+    for i=basis(pb), j=basis(pb)
+        allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
+    end
+    @test allpass
+    pb = subroutine(4, matblock(rand_unitary(4)), (4,2))
+    mpb = mat(pb)
+    allpass = true
+    for i=basis(pb), j=basis(pb)
+        allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
+    end
+    @test allpass
+end

--- a/lib/YaoBlocks/test/composite/subroutine.jl
+++ b/lib/YaoBlocks/test/composite/subroutine.jl
@@ -44,7 +44,7 @@ end
     @test YaoBlocks.PropertyTrait(s) == YaoBlocks.PreserveAll()
 end
 
-@testset "getindex2" begin
+@testset "instruct_get_element" begin
     for pb in [subroutine(3, Y, (2,)), subroutine(4, matblock(rand_unitary(4)), (4,2))]
         mpb = mat(pb)
         allpass = true

--- a/lib/YaoBlocks/test/composite/subroutine.jl
+++ b/lib/YaoBlocks/test/composite/subroutine.jl
@@ -59,4 +59,10 @@ end
         allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
     end
     @test allpass
+
+    allpass = true
+    for j=basis(pb)
+        allpass &= vec(pb[:, j]) == mpb[:, Int(j)+1]
+    end
+    @test allpass
 end

--- a/lib/YaoBlocks/test/composite/subroutine.jl
+++ b/lib/YaoBlocks/test/composite/subroutine.jl
@@ -45,24 +45,20 @@ end
 end
 
 @testset "getindex2" begin
-    pb = subroutine(3, Y, (2,))
-    mpb = mat(pb)
-    allpass = true
-    for i=basis(pb), j=basis(pb)
-        allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
-    end
-    @test allpass
-    pb = subroutine(4, matblock(rand_unitary(4)), (4,2))
-    mpb = mat(pb)
-    allpass = true
-    for i=basis(pb), j=basis(pb)
-        allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
-    end
-    @test allpass
+    for pb in [subroutine(3, Y, (2,)), subroutine(4, matblock(rand_unitary(4)), (4,2))]
+        mpb = mat(pb)
+        allpass = true
+        for i=basis(pb), j=basis(pb)
+            allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
+        end
+        @test allpass
 
-    allpass = true
-    for j=basis(pb)
-        allpass &= vec(pb[:, j]) == mpb[:, Int(j)+1]
+        allpass = true
+        for j=basis(pb)
+            allpass &= vec(pb[:, j]) == mpb[:, Int(j)+1]
+            allpass &= vec(pb[:, EntryTable([j], [1.0+0im])]) == mpb[:, Int(j)+1]
+            allpass &= vec(pb[j, :]) == mpb[Int(j)+1, :]
+        end
+        @test allpass
     end
-    @test allpass
 end

--- a/lib/YaoBlocks/test/composite/tag.jl
+++ b/lib/YaoBlocks/test/composite/tag.jl
@@ -79,18 +79,18 @@ end
 end
 
 @testset "getindex2: dagger, scale" begin
-    pb = 3*put(3, 2=>2*matblock(rand_unitary(2)))'
-    mpb = mat(pb)
-    allpass = true
-    for i=basis(pb), j=basis(pb)
-        allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
+    for pb in [3*put(3, 2=>2*matblock(rand_unitary(2)))', Val(2) * Daggered(put(4, (4,2)=>-matblock(rand_unitary(9); nlevel=3)))]
+        mpb = mat(pb)
+        allpass = true
+        for i=basis(pb), j=basis(pb)
+            allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
+        end
+        @test allpass
+
+        allpass = true
+        for i=basis(pb), j=basis(pb)
+            allpass &= vec(pb[:, j]) == mpb[:, Int(j)+1]
+        end
+        @test allpass
     end
-    @test allpass
-    pb = Val(2) * Daggered(put(4, (4,2)=>-matblock(rand_unitary(9); nlevel=3)))
-    mpb = mat(pb)
-    allpass = true
-    for i=basis(pb), j=basis(pb)
-        allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
-    end
-    @test allpass
 end

--- a/lib/YaoBlocks/test/composite/tag.jl
+++ b/lib/YaoBlocks/test/composite/tag.jl
@@ -78,7 +78,7 @@ end
     @test chsubblocks(dg, X) == Daggered(X)
 end
 
-@testset "getindex2: dagger, scale" begin
+@testset "instruct_get_element: dagger, scale" begin
     for pb in [3*put(3, 2=>2*matblock(rand_unitary(2)))', Val(2) * Daggered(put(4, (4,2)=>-matblock(rand_unitary(9); nlevel=3)))]
         mpb = mat(pb)
         allpass = true

--- a/lib/YaoBlocks/test/composite/tag.jl
+++ b/lib/YaoBlocks/test/composite/tag.jl
@@ -77,3 +77,20 @@ end
     @test apply!(product_state(bit"1"), dg) ≈ apply!(product_state(bit"1"), ConstGate.Tdag)
     @test chsubblocks(dg, X) == Daggered(X)
 end
+
+@testset "getindex2: dagger, scale" begin
+    pb = 3*put(3, 2=>2*matblock(rand_unitary(2)))'
+    mpb = mat(pb)
+    allpass = true
+    for i=basis(pb), j=basis(pb)
+        allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
+    end
+    @test allpass
+    pb = Val(2) * Daggered(put(4, (4,2)=>-matblock(rand_unitary(9); nlevel=3)))
+    mpb = mat(pb)
+    allpass = true
+    for i=basis(pb), j=basis(pb)
+        allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
+    end
+    @test allpass
+end

--- a/lib/YaoBlocks/test/primitive/const_gate.jl
+++ b/lib/YaoBlocks/test/primitive/const_gate.jl
@@ -110,7 +110,7 @@ end
     @test mat(P1) ≈ [0 0;0 1]
 end
 
-@testset "getindex2" begin
+@testset "instruct_get_element" begin
     for pb in [X, Y, Z, I2, S, T, Pu, Pd, P0, P1]
         mpb = mat(pb)
         allpass = true

--- a/lib/YaoBlocks/test/primitive/const_gate.jl
+++ b/lib/YaoBlocks/test/primitive/const_gate.jl
@@ -126,4 +126,9 @@ end
         end
         @test allpass
     end
+    # regression test
+    @test P0[:,bit"0"] |> length == 1
+    @test P0[:,bit"1"] |> length == 0
+    @test P1[:,bit"0"] |> length == 0
+    @test P1[:,bit"1"] |> length == 1
 end

--- a/lib/YaoBlocks/test/primitive/const_gate.jl
+++ b/lib/YaoBlocks/test/primitive/const_gate.jl
@@ -109,3 +109,21 @@ end
     @test mat(P0) ≈ [1 0;0 0]
     @test mat(P1) ≈ [0 0;0 1]
 end
+
+@testset "getindex2" begin
+    for pb in [X, Y, Z, I2, S, T, Pu, Pd, P0, P1]
+        mpb = mat(pb)
+        allpass = true
+        for i=basis(pb), j=basis(pb)
+            allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
+        end
+        @test allpass
+
+        allpass = true
+        for j=basis(pb)
+            allpass &= vec(pb[:, j]) == mpb[:, Int(j)+1]
+            allpass &= vec(pb[j,:]) == mpb[Int(j)+1,:]
+        end
+        @test allpass
+    end
+end

--- a/lib/YaoBlocks/test/primitive/general_matrix_gate.jl
+++ b/lib/YaoBlocks/test/primitive/general_matrix_gate.jl
@@ -27,3 +27,25 @@ a = rand_unitary(2) .|> ComplexF32
 
 @test !isdiagonal(matblock(randn(64, 64)))
 @test isdiagonal(matblock(Diagonal(randn(128))))
+
+@testset "getindex2" begin
+    for pb in [matblock(mat(kron(X,X))),
+            matblock(rand_unitary(9); nlevel=3),
+            matblock(mat(igate(2))),
+            matblock(sprand(ComplexF64, 4,4,0.5)),
+            ]
+        mpb = mat(pb)
+        allpass = true
+        for i=basis(pb), j=basis(pb)
+            allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
+        end
+        @test allpass
+
+        allpass = true
+        for j=basis(pb)
+            allpass &= vec(pb[:, j]) == mpb[:, Int(j)+1]
+            allpass &= vec(pb[j,:]) == mpb[Int(j)+1,:]
+        end
+        @test allpass
+    end
+end

--- a/lib/YaoBlocks/test/primitive/general_matrix_gate.jl
+++ b/lib/YaoBlocks/test/primitive/general_matrix_gate.jl
@@ -30,7 +30,7 @@ a = rand_unitary(2) .|> ComplexF32
 @test !isdiagonal(matblock(randn(64, 64)))
 @test isdiagonal(matblock(Diagonal(randn(128))))
 
-@testset "getindex2" begin
+@testset "instruct_get_element" begin
     for pb in [matblock(mat(kron(X,X))),
             matblock(rand_unitary(9); nlevel=3),
             matblock(mat(igate(2))),

--- a/lib/YaoBlocks/test/primitive/general_matrix_gate.jl
+++ b/lib/YaoBlocks/test/primitive/general_matrix_gate.jl
@@ -1,4 +1,6 @@
 using Test, Random, LinearAlgebra, YaoArrayRegister, YaoBlocks, YaoAPI
+using SparseArrays: sprand
+using YaoArrayRegister.LuxurySparse: pmrand
 
 A = rand(ComplexF64, 4, 4)
 mg = matblock(A)

--- a/lib/YaoBlocks/test/primitive/identity_gate.jl
+++ b/lib/YaoBlocks/test/primitive/identity_gate.jl
@@ -17,7 +17,7 @@ using Random, Test
 end
 
 
-@testset "getindex2" begin
+@testset "instruct_get_element" begin
     for pb in [igate(1), igate(2; nlevel=3)
             ]
         mpb = mat(pb)

--- a/lib/YaoBlocks/test/primitive/identity_gate.jl
+++ b/lib/YaoBlocks/test/primitive/identity_gate.jl
@@ -15,3 +15,23 @@ using Random, Test
     @test nqudits(igate(3; nlevel=3)) == 3
     @test mat(igate(3; nlevel=3)) == YaoBlocks.IMatrix{27}()
 end
+
+
+@testset "getindex2" begin
+    for pb in [igate(1), igate(2; nlevel=3)
+            ]
+        mpb = mat(pb)
+        allpass = true
+        for i=basis(pb), j=basis(pb)
+            allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
+        end
+        @test allpass
+
+        allpass = true
+        for j=basis(pb)
+            allpass &= vec(pb[:, j]) == mpb[:, Int(j)+1]
+            allpass &= vec(pb[j,:]) == mpb[Int(j)+1,:]
+        end
+        @test allpass
+    end
+end

--- a/lib/YaoBlocks/test/primitive/primitive.jl
+++ b/lib/YaoBlocks/test/primitive/primitive.jl
@@ -34,3 +34,5 @@ end
 
 # it does nothing
 @test chsubblocks(X, Y) === X
+@test X[bit"1", bit"0"] == 1
+@test X[bit"1", bit"1"] == 0

--- a/lib/YaoBlocks/test/primitive/rotation_gate.jl
+++ b/lib/YaoBlocks/test/primitive/rotation_gate.jl
@@ -81,3 +81,22 @@ end
     end
     @test allpass
 end
+
+@testset "getindex2" begin
+    for pb in [Rx(0.5), rot(SWAP, 0.5), shift(0.5), phase(0.5)
+            ]
+        mpb = mat(pb)
+        allpass = true
+        for i=basis(pb), j=basis(pb)
+            allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
+        end
+        @test allpass
+
+        allpass = true
+        for j=basis(pb)
+            allpass &= vec(pb[:, j]) == mpb[:, Int(j)+1]
+            allpass &= vec(pb[j,:]) == mpb[Int(j)+1,:]
+        end
+        @test allpass
+    end
+end

--- a/lib/YaoBlocks/test/primitive/rotation_gate.jl
+++ b/lib/YaoBlocks/test/primitive/rotation_gate.jl
@@ -72,7 +72,7 @@ end
     @test occupied_locs(g) == (2,)
 end
 
-@testset "getindex2" begin
+@testset "instruct_get_element" begin
     pb = rot(Y, 0.4)
     mpb = mat(pb)
     allpass = true
@@ -82,7 +82,7 @@ end
     @test allpass
 end
 
-@testset "getindex2" begin
+@testset "instruct_get_element" begin
     for pb in [Rx(0.5), rot(SWAP, 0.5), shift(0.5), phase(0.5)
             ]
         mpb = mat(pb)

--- a/lib/YaoBlocks/test/primitive/rotation_gate.jl
+++ b/lib/YaoBlocks/test/primitive/rotation_gate.jl
@@ -71,3 +71,13 @@ end
     g = rot(put(5, 2 => X), 0.5)
     @test occupied_locs(g) == (2,)
 end
+
+@testset "getindex2" begin
+    pb = rot(Y, 0.4)
+    mpb = mat(pb)
+    allpass = true
+    for i=basis(pb), j=basis(pb)
+        allpass &= pb[i, j] == mpb[Int(i)+1, Int(j)+1]
+    end
+    @test allpass
+end

--- a/lib/YaoBlocks/test/primitive/time_evolution.jl
+++ b/lib/YaoBlocks/test/primitive/time_evolution.jl
@@ -116,6 +116,8 @@ end
         for j=basis(pb)
             allpass &= vec(pb[:, j]) ≈ mpb[:, Int(j)+1]
             allpass &= vec(pb[j,:]) ≈ mpb[Int(j)+1,:]
+            allpass &= vec(pb[:, EntryTable([j], [1.0+0im])]) ≈ mpb[:, Int(j)+1]
+            allpass &= vec(pb[EntryTable([j], [1.0+0im]),:]) ≈ mpb[Int(j)+1,:]
         end
         @test allpass
     end

--- a/lib/YaoBlocks/test/primitive/time_evolution.jl
+++ b/lib/YaoBlocks/test/primitive/time_evolution.jl
@@ -101,3 +101,13 @@ end
     @test nlevel(reg2) == 3
     @test isnormalized(reg2)
 end
+
+@testset "getindex2" begin
+    pb = time_evolve(put(3, 2=>Y), 0.5)
+    mpb = mat(pb)
+    allpass = true
+    for i=basis(pb), j=basis(pb)
+        allpass &= pb[i, j] ≈ mpb[Int(i)+1, Int(j)+1]
+    end
+    @test allpass
+end

--- a/lib/YaoBlocks/test/primitive/time_evolution.jl
+++ b/lib/YaoBlocks/test/primitive/time_evolution.jl
@@ -102,7 +102,7 @@ end
     @test isnormalized(reg2)
 end
 
-@testset "getindex2" begin
+@testset "instruct_get_element" begin
     for pb in [time_evolve(put(3, 2=>Y), 0.5), time_evolve(cache(put(3, (3,1)=>matblock(rand_hermitian(9); nlevel=3))), 0.5)
             ]
         mpb = mat(pb)

--- a/lib/YaoBlocks/test/primitive/time_evolution.jl
+++ b/lib/YaoBlocks/test/primitive/time_evolution.jl
@@ -103,11 +103,20 @@ end
 end
 
 @testset "getindex2" begin
-    pb = time_evolve(put(3, 2=>Y), 0.5)
-    mpb = mat(pb)
-    allpass = true
-    for i=basis(pb), j=basis(pb)
-        allpass &= pb[i, j] ≈ mpb[Int(i)+1, Int(j)+1]
+    for pb in [time_evolve(put(3, 2=>Y), 0.5), time_evolve(cache(put(3, (3,1)=>matblock(rand_hermitian(9); nlevel=3))), 0.5)
+            ]
+        mpb = mat(pb)
+        allpass = true
+        for i=basis(pb), j=basis(pb)
+            allpass &= pb[i, j] ≈ mpb[Int(i)+1, Int(j)+1]
+        end
+        @test allpass
+
+        allpass = true
+        for j=basis(pb)
+            allpass &= vec(pb[:, j]) ≈ mpb[:, Int(j)+1]
+            allpass &= vec(pb[j,:]) ≈ mpb[Int(j)+1,:]
+        end
+        @test allpass
     end
-    @test allpass
 end

--- a/lib/YaoBlocks/test/rountines.jl
+++ b/lib/YaoBlocks/test/rountines.jl
@@ -7,7 +7,7 @@ import YaoBlocks: u1mat, unmat, cunmat, unij!
     mmm = Rx(0.5) |> mat
     m1 = u1mat(nbit, mmm, 2)
     m2 = YaoArrayRegister.linop2dense(v -> instruct!(Val(2), v, mmm, (2,)), nbit)
-    m3 = unmat(nbit, mmm, (2,))
+    m3 = unmat(Val(2), nbit, mmm, (2,))
     @test m1 ≈ m2
     @test m1 ≈ m3
 
@@ -36,7 +36,7 @@ end
 
     nbit = 4
     mmm = X |> mat
-    m1 = unmat(nbit, mmm, (2,))
+    m1 = unmat(Val(2), nbit, mmm, (2,))
     m2 = YaoArrayRegister.linop2dense(v -> instruct!(Val(2), v, mmm, (2,)), nbit)
     @test m1 ≈ m2
 end
@@ -44,7 +44,7 @@ end
 @testset "identity-unmat" begin
     nbit = 4
     mmm = Z |> mat
-    m1 = unmat(nbit, mmm, (2,))
+    m1 = unmat(Val(2), nbit, mmm, (2,))
     m2 = YaoArrayRegister.linop2dense(v -> instruct!(Val(2), v, mmm, (2,)), nbit)
     @test m1 ≈ m2
 end

--- a/lib/YaoBlocks/test/utils.jl
+++ b/lib/YaoBlocks/test/utils.jl
@@ -1,5 +1,6 @@
 using YaoBlocks
 using YaoBlocks: sprand_hermitian, sprand_unitary
+using SparseArrays: sparse
 
 @testset "random matrices" begin
     mat = rand_unitary(8)
@@ -14,4 +15,16 @@ end
 @testset "projector" begin
     @test projector(0) ≈ [1 0; 0 0]
     @test projector(1) ≈ [0 0; 0 1]
+end
+
+@testset "entry table" begin
+    for table in [EntryTable(BitStr64{3}[], ComplexF64[]),
+        EntryTable([bit"000", bit"101", bit"001", bit"101", bit"101", bit"000"], randn(ComplexF64, 6))
+        ]
+        @test vec(table) == sparse(table)
+        @test vec(table) == vec(cleanup(table))
+        println(table)
+    end
+    e1 = EntryTable([bit"001"], [2.0])
+    @test merge(e1,e1,e1) == EntryTable([bit"001",bit"001",bit"001"], fill(2.0, 3))
 end

--- a/lib/YaoBlocks/test/utils.jl
+++ b/lib/YaoBlocks/test/utils.jl
@@ -2,6 +2,7 @@ using YaoBlocks
 using YaoBlocks: sprand_hermitian, sprand_unitary
 using SparseArrays: sparse
 using BitBasis
+using Test
 
 @testset "random matrices" begin
     mat = rand_unitary(8)
@@ -28,4 +29,7 @@ end
     end
     e1 = EntryTable([bit"001"], [2.0])
     @test merge(e1,e1,e1) == EntryTable([bit"001",bit"001",bit"001"], fill(2.0, 3))
+
+    et = EntryTable([bit"000",bit"011",bit"101",bit"101",bit"011",bit"110",bit"110",bit"011",], [1.0 + 0.0im,-1, 1,1,1,-1,1,1,-1])
+    @test cleanup(et) |> length == 3
 end

--- a/lib/YaoBlocks/test/utils.jl
+++ b/lib/YaoBlocks/test/utils.jl
@@ -1,6 +1,7 @@
 using YaoBlocks
 using YaoBlocks: sprand_hermitian, sprand_unitary
 using SparseArrays: sparse
+using BitBasis
 
 @testset "random matrices" begin
     mat = rand_unitary(8)

--- a/lib/YaoSym/Project.toml
+++ b/lib/YaoSym/Project.toml
@@ -12,7 +12,7 @@ YaoArrayRegister = "e600142f-9330-5003-8abb-0ebd767abc51"
 YaoBlocks = "418bc28f-b43b-5e0b-a6e7-61bbc1a2c1df"
 
 [compat]
-BitBasis = "0.7"
+BitBasis = "0.8"
 LuxurySparse = "0.6"
 Requires = "1"
 SymEngine = "0.8"

--- a/lib/YaoSym/src/symengine/instruct.jl
+++ b/lib/YaoSym/src/symengine/instruct.jl
@@ -1,14 +1,14 @@
 using ..SymEngine
-import YaoArrayRegister: rot_mat
+import YaoArrayRegister: parametric_mat
 
-rot_mat(::Type{T}, ::Val{:Rx}, theta::Basic) where {T} =
+parametric_mat(::Type{T}, ::Val{:Rx}, theta::Basic) where {T} =
     Basic[cos(theta / 2) -im*sin(theta / 2); -im*sin(theta / 2) cos(theta / 2)]
-rot_mat(::Type{T}, ::Val{:Ry}, theta::Basic) where {T} =
+parametric_mat(::Type{T}, ::Val{:Ry}, theta::Basic) where {T} =
     Basic[cos(theta / 2) -sin(theta / 2); sin(theta / 2) cos(theta / 2)]
-rot_mat(::Type{T}, ::Val{:Rz}, theta::Basic) where {T} =
+parametric_mat(::Type{T}, ::Val{:Rz}, theta::Basic) where {T} =
     Diagonal(Basic[exp(-im * theta / 2), exp(im * theta / 2)])
-rot_mat(::Type{T}, ::Val{:CPHASE}, theta::Basic) where {T} = Diagonal(Basic[1, 1, 1, exp(im * theta)])
-rot_mat(::Type{T}, ::Val{:PSWAP}, theta::Basic) where {T} = rot_mat(Basic, Const.SWAP, theta)
+parametric_mat(::Type{T}, ::Val{:CPHASE}, theta::Basic) where {T} = Diagonal(Basic[1, 1, 1, exp(im * theta)])
+parametric_mat(::Type{T}, ::Val{:PSWAP}, theta::Basic) where {T} = parametric_mat(Basic, Const.SWAP, theta)
 
 for G in [:Rx, :Ry, :Rz, :CPHASE]
     # forward single gates
@@ -20,7 +20,7 @@ for G in [:Rx, :Ry, :Rz, :CPHASE]
         control_bits::NTuple{N2,Int},
         theta::Basic,
     ) where {T,N1,N2,N3}
-        m = rot_mat(T, g, theta)
+        m = parametric_mat(T, g, theta)
         instruct!(Val(2), state, m, locs, control_locs, control_bits)
     end
 

--- a/src/EasyBuild/easybuild.jl
+++ b/src/EasyBuild/easybuild.jl
@@ -1,6 +1,8 @@
 module EasyBuild
 using YaoBlocks, YaoBlocks.LuxurySparse, YaoBlocks.YaoAPI, YaoBlocks.YaoArrayRegister
 using YaoBlocks.LinearAlgebra
+using YaoArrayRegister: sparse
+
 include("block_extension/blocks.jl")
 include("general_U4.jl")
 include("phaseestimation.jl")

--- a/src/EasyBuild/hamiltonians.jl
+++ b/src/EasyBuild/hamiltonians.jl
@@ -39,9 +39,9 @@ function rydberg_chain(nbits::Int; Ω::Number=0.0, Δ::Real=0.0, V::Real=0.0, r:
     Y1r = matblock(sparse([3, 2], [2, 3], [1.0im, -1.0im], 3, 3); nlevel=3)
     # single site term in {|1>, |r>}.
     h = Add(nbits; nlevel=3)
-    !iszero(Δ) && push!(h, Δ * sum([put(nbits, i=>Z1r) for i=1:nbits]))
-    !iszero(real(Ω)) && push!(h, real(Ω) * sum([put(nbits, i=>X1r) for i=1:nbits]))
-    !iszero(imag(Ω)) && push!(h, imag(Ω) * sum([put(nbits, i=>Y1r) for i=1:nbits]))
+    !iszero(Δ) && push!(h, (-Δ) * sum([put(nbits, i=>Pr) for i=1:nbits]))
+    !iszero(real(Ω)) && push!(h, real(Ω)/2 * sum([put(nbits, i=>X1r) for i=1:nbits]))
+    !iszero(imag(Ω)) && push!(h, imag(Ω)/2 * sum([put(nbits, i=>Y1r) for i=1:nbits]))
     # interaction
     !iszero(V) && push!(h, V * sum([put(nbits, (i,i+1)=>kron(Pr, Pr)) for i=1:nbits-1]))
     # Raman term

--- a/src/EasyBuild/hamiltonians.jl
+++ b/src/EasyBuild/hamiltonians.jl
@@ -1,4 +1,4 @@
-export heisenberg, transverse_ising
+export heisenberg, transverse_ising, rydberg_chain
 
 """
     heisenberg(nbit::Int; periodic::Bool=true)
@@ -28,4 +28,23 @@ function transverse_ising(nbit::Int, h::Number; periodic::Bool=true)
         repeat(nbit,Z,(i,i%nbit+1))
     end |> sum
     ising_term + h*sum(map(i->put(nbit,i=>X), 1:nbit))
+end
+
+# a 3 level hamiltonian
+function rydberg_chain(nbits::Int; Ω::Number=0.0, Δ::Real=0.0, V::Real=0.0, r::Real=0.0)
+    Pr = matblock(sparse([3], [3], [1.0+0im], 3, 3); nlevel=3)
+    Z1r = matblock(sparse([2, 3], [2, 3], [1.0+0im, -1.0], 3, 3); nlevel=3)
+    X1r = matblock(sparse([2, 3], [3, 2], [1.0+0im, 1.0], 3, 3); nlevel=3)
+    X01 = matblock(sparse([1, 2], [2, 1], [1.0+0im, 1.0], 3, 3); nlevel=3)
+    Y1r = matblock(sparse([3, 2], [2, 3], [1.0im, -1.0im], 3, 3); nlevel=3)
+    # single site term in {|1>, |r>}.
+    h = Add(nbits; nlevel=3)
+    !iszero(Δ) && push!(h, Δ * sum([put(nbits, i=>Z1r) for i=1:nbits]))
+    !iszero(real(Ω)) && push!(h, real(Ω) * sum([put(nbits, i=>X1r) for i=1:nbits]))
+    !iszero(imag(Ω)) && push!(h, imag(Ω) * sum([put(nbits, i=>Y1r) for i=1:nbits]))
+    # interaction
+    !iszero(V) && push!(h, V * sum([put(nbits, (i,i+1)=>kron(Pr, Pr)) for i=1:nbits-1]))
+    # Raman term
+    !iszero(r) && push!(h, r * sum([put(nbits, i=>X01) for i=1:nbits]))
+    return h
 end

--- a/src/EasyBuild/hamiltonians.jl
+++ b/src/EasyBuild/hamiltonians.jl
@@ -40,10 +40,11 @@ function rydberg_chain(nbits::Int; Ω::Number=0.0, Δ::Real=0.0, V::Real=0.0, r:
     # single site term in {|1>, |r>}.
     h = Add(nbits; nlevel=3)
     !iszero(Δ) && push!(h, (-Δ) * sum([put(nbits, i=>Pr) for i=1:nbits]))
+    #!iszero(Δ) && push!(h, (-Δ/2) * sum([put(nbits, i=>Z1r) for i=1:nbits]))
     !iszero(real(Ω)) && push!(h, real(Ω)/2 * sum([put(nbits, i=>X1r) for i=1:nbits]))
     !iszero(imag(Ω)) && push!(h, imag(Ω)/2 * sum([put(nbits, i=>Y1r) for i=1:nbits]))
     # interaction
-    !iszero(V) && push!(h, V * sum([put(nbits, (i,i+1)=>kron(Pr, Pr)) for i=1:nbits-1]))
+    !iszero(V) && nbits > 1 && push!(h, V * sum([put(nbits, (i,i+1)=>kron(Pr, Pr)) for i=1:nbits-1]))
     # Raman term
     !iszero(r) && push!(h, r * sum([put(nbits, i=>X01) for i=1:nbits]))
     return h

--- a/test/easybuild/hamiltonians.jl
+++ b/test/easybuild/hamiltonians.jl
@@ -40,7 +40,8 @@ end
     h2 = rydberg_chain(nbits; Ω=Ω*exp(im*ξ), Δ=Δf*Ω, V)
     levine_pichler_pulse = chain(time_evolve(h1, 2τ), time_evolve(h2, 2τ))
     # half pulse drives |11> to |11>
-    m11 = mat(levine_pichler_pulse[1])[Int(dit"11;3")+1, Int(dit"11;3")+1]
+    i, j = dit"01;3", dit"11;3"
+    m11 = levine_pichler_pulse[1][j, j]
     @test isapprox(m11 |> abs, 1; atol=1e-3)
     @show angle(m11) / π
     @test mat(levine_pichler_pulse) * reg.state ≈ apply(reg, levine_pichler_pulse).state
@@ -48,14 +49,10 @@ end
     println()
     print_table(reg)
 
-    bases = basis(reg)
     h = levine_pichler_pulse
-    m = mat(h)
-    i = Int(dit"01;3")+1
-    j = Int(dit"11;3")+1
-    ang1 = angle(m[i, i]) / π
-    ang2 = angle(m[j, j]) / π
-    @show abs(m[i,i])
+    ang1 = angle(h[i, i]) / π
+    ang2 = angle(h[j, j]) / π
+    @show abs(h[i,i])
     @show 2*ang1, ang2
     @test isapprox(ang2+2, 4*Δf/sqrt(Δf^2 + 2*Ω^2); rtol=1e-2)
     @show ang1

--- a/test/easybuild/hamiltonians.jl
+++ b/test/easybuild/hamiltonians.jl
@@ -1,6 +1,7 @@
-using Yao.EasyBuild
+using Yao, Yao.EasyBuild
 using Test
 using Yao.ConstGate
+using YaoArrayRegister.SparseArrays
 
 @testset "solving hamiltonian" begin
     nbit = 8
@@ -19,6 +20,26 @@ end
     apply!(reg, time_evolve(rydberg_chain(nbits; r=1.0), π/4))
     expected = join(fill(arrayreg([1.0, -im, 0]; nlevel=3), nbits)...) |> normalize!
     @test reg ≈ expected
+    #@show reg.state
+    print_table(reg)
 
-    h = rydberg_chain(Ω = 1.0, Δ = 0.377Ω, V=10.0)
+    #dt = 2.732π/2
+    Ω = 1.0
+    τ = 4.29268/Ω/2
+    Δ = 0.377371 * Ω
+    V = 1e5
+    h1 = rydberg_chain(nbits; Ω=Ω, Δ, V)
+    h2 = rydberg_chain(nbits; Ω=-Ω, Δ, V)
+    levine_pichler_pulse = chain(time_evolve(h1, τ), time_evolve(h2, τ))
+    @test mat(levine_pichler_pulse) * reg.state ≈ apply(reg, levine_pichler_pulse).state
+    apply!(reg, levine_pichler_pulse)
+    # println()
+    # print_table(reg)
+    println()
+    print_table(reg)
+
+    bases = basis(reg)
+    for (i,j,v) in zip(findnz(SparseMatrixCSC(round.(mat(levine_pichler_pulse), digits=5)))...)
+        abs(v) > 1e-1 && println(bases[i], "→", bases[j], "   ", v)
+    end
 end

--- a/test/easybuild/hamiltonians.jl
+++ b/test/easybuild/hamiltonians.jl
@@ -38,7 +38,9 @@ end
     h2 = rydberg_chain(nbits; Ω=Ω*exp(im*ξ), Δ=Δf*Ω, V)
     levine_pichler_pulse = chain(time_evolve(h1, 2τ), time_evolve(h2, 2τ))
     # half pulse drives |11> to |11>
-    @test isapprox(mat(levine_pichler_pulse[1])[Int(dit"11;3")+1, Int(dit"11;3")+1] |> abs, 1; atol=1e-3)
+    m11 = mat(levine_pichler_pulse[1])[Int(dit"11;3")+1, Int(dit"11;3")+1]
+    @test isapprox(m11 |> abs, 1; atol=1e-3)
+    @show angle(m11) / π
     @test mat(levine_pichler_pulse) * reg.state ≈ apply(reg, levine_pichler_pulse).state
     reg = apply(reg, levine_pichler_pulse)
     println()
@@ -52,8 +54,43 @@ end
     j = Int(dit"11;3")+1
     ang1 = angle(m[i, i]) / π
     ang2 = angle(m[j, j]) / π
+    @show abs(m[i,i])
+    @show 2*ang1, ang2
+    @test isapprox(ang2+2, 4*Δf/sqrt(Δf^2 + 2*Ω^2); rtol=1e-2)
+    @show ang1
     @show 2*ang1 - ang2-1
     # for (i,j,v) in zip(findnz(SparseMatrixCSC(round.(mat(h), digits=5)))...)
     #     abs(v) > 1e-1 && println(bases[i], "→", bases[j], "   ", v)
     # end
 end
+
+#Δ = 0.377371
+function lp(Δ::T, ξ::T) where T
+    Ω = one(T)
+    τ = T(4.29268/Ω)
+    V = T(1e3)
+    nbits = 2
+    h1 = rydberg_chain(nbits; Ω=Ω, Δ=Δ, V)
+    h2 = rydberg_chain(nbits; Ω=Ω*exp(im*ξ), Δ=Δ, V)
+    levine_pichler_pulse = chain(time_evolve(h1, 2τ), time_evolve(h2, 2τ))
+ 
+    m = mat(Complex{T}, levine_pichler_pulse)
+    i = Int(dit"01;3")+1
+    j = Int(dit"11;3")+1
+    ang1 = angle(m[i, i]) / π
+    ang2 = angle(m[j, j]) / π
+
+    #@test isapprox(ang2+2, 4*Δ/sqrt(Δf^2 + 2*Ω^2); rtol=1e-2)
+    #@show 2*ang1 - ang2-1
+    diff = mod(2*ang1 - ang2-1, 2)
+    abs(m[i,i]), abs(m[j,j]), min(abs(diff), abs(diff-2))
+end
+
+function f(x)
+    res = lp(x...)
+    (1-res[1]) + (1-res[2]) + res[3]
+end
+
+using ForwardDiff, Optim
+Base.exp(m::AbstractMatrix{Complex{T}}) where T<:ForwardDiff.Dual = YaoBlocks.ExponentialUtilities.exp_generic(m)
+opt = Optim.optimize(f, [0.4, 1.0], LBFGS(); inplace=false)

--- a/test/easybuild/hamiltonians.jl
+++ b/test/easybuild/hamiltonians.jl
@@ -62,25 +62,3 @@ end
     #     abs(v) > 1e-1 && println(bases[i], "→", bases[j], "   ", v)
     # end
 end
-
-#Δ = 0.377371
-function lp(Δ::T, ξ::T) where T
-    Ω = one(T)
-    τ = T(4.29268/Ω)
-    V = T(1e3)
-    nbits = 2
-    h1 = rydberg_chain(nbits; Ω=Ω, Δ=Δ, V)
-    h2 = rydberg_chain(nbits; Ω=Ω*exp(im*ξ), Δ=Δ, V)
-    levine_pichler_pulse = chain(time_evolve(h1, 2τ), time_evolve(h2, 2τ))
- 
-    m = mat(Complex{T}, levine_pichler_pulse)
-    i = Int(dit"01;3")+1
-    j = Int(dit"11;3")+1
-    ang1 = angle(m[i, i]) / π
-    ang2 = angle(m[j, j]) / π
-
-    #@test isapprox(ang2+2, 4*Δ/sqrt(Δf^2 + 2*Ω^2); rtol=1e-2)
-    #@show 2*ang1 - ang2-1
-    diff = mod(2*ang1 - ang2-1, 2)
-    abs(m[i,i]), abs(m[j,j]), min(abs(diff), abs(diff-2))
-end

--- a/test/easybuild/hamiltonians.jl
+++ b/test/easybuild/hamiltonians.jl
@@ -9,3 +9,16 @@ using Yao.ConstGate
     h = transverse_ising(nbit, 1.0)
     @test ishermitian(h)
 end
+
+# https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.123.170503
+@testset "Levine Pichler pulse" begin
+    nbits = 2
+    reg = zero_state(nbits; nlevel=3)
+    # prepare all states in (|0> - i|1>)/sqrt(2)
+    # time evolve π/4 with the Raman pulse Hamiltonian is equivalent to doing a X rotation π/2
+    apply!(reg, time_evolve(rydberg_chain(nbits; r=1.0), π/4))
+    expected = join(fill(arrayreg([1.0, -im, 0]; nlevel=3), nbits)...) |> normalize!
+    @test reg ≈ expected
+
+    h = rydberg_chain(Ω = 1.0, Δ = 0.377Ω, V=10.0)
+end

--- a/test/easybuild/hamiltonians.jl
+++ b/test/easybuild/hamiltonians.jl
@@ -84,12 +84,3 @@ function lp(Δ::T, ξ::T) where T
     diff = mod(2*ang1 - ang2-1, 2)
     abs(m[i,i]), abs(m[j,j]), min(abs(diff), abs(diff-2))
 end
-
-function f(x)
-    res = lp(x...)
-    (1-res[1]) + (1-res[2]) + res[3]
-end
-
-using ForwardDiff, Optim
-Base.exp(m::AbstractMatrix{Complex{T}}) where T<:ForwardDiff.Dual = YaoBlocks.ExponentialUtilities.exp_generic(m)
-opt = Optim.optimize(f, [0.4, 1.0], LBFGS(); inplace=false)

--- a/test/easybuild/hamiltonians.jl
+++ b/test/easybuild/hamiltonians.jl
@@ -46,7 +46,6 @@ end
     println()
     print_table(reg)
 
-    # TODO: add block[dit"...", dit"..."]
     bases = basis(reg)
     h = levine_pichler_pulse
     m = mat(h)

--- a/test/easybuild/hamiltonians.jl
+++ b/test/easybuild/hamiltonians.jl
@@ -7,8 +7,10 @@ using YaoArrayRegister.SparseArrays
     nbit = 8
     h = heisenberg(nbit) |> cache
     @test ishermitian(h)
+    @test vec(h[:,bit"01001000"] |> cleanup) ≈ mat(h)[:, buffer(bit"01001000")+1]
     h = transverse_ising(nbit, 1.0)
     @test ishermitian(h)
+    @test vec(h[:,bit"01001000"] |> cleanup) ≈ mat(h)[:, buffer(bit"01001000")+1]
 end
 
 # https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.123.170503


### PR DESCRIPTION
## Measuring Qudits
```julia
julia> using Yao

julia> measure(product_state(dit"012;3"); nshots=3)
3-element Vector{BitBasis.DitStr64{3, 3}}:
 012 ₍₃₎
 012 ₍₃₎
 012 ₍₃₎
```
## Dit string Indexing
Now you can play with operators indexing and propagation.
```julia
julia> using Yao

julia> h = EasyBuild.heisenberg(60);

julia> cleanup(h[:,cleanup(h[:,BitStr{60}(234)])]) |> length
22

julia> @time cleanup(h[:,cleanup(h[:,BitStr{60}(234)])]);
  0.017032 seconds (169.35 k allocations: 4.729 MiB)

julia> @btime $h[BitStr{60}(235),BitStr{60}(234)]
  161.038 μs (1213 allocations: 57.03 KiB)
0.0 + 0.0im

julia> h[:,BitStr{60}(234)] |> cleanup
EntryTable{DitStr{2, 60, Int64}, ComplexF64}:
  000000000000000000000000000000000000000000000000000011011010 ₍₂₎   2.0 + 0.0im
  000000000000000000000000000000000000000000000000000011100110 ₍₂₎   2.0 + 0.0im
  000000000000000000000000000000000000000000000000000011101001 ₍₂₎   2.0 + 0.0im
  000000000000000000000000000000000000000000000000000011101010 ₍₂₎   48.0 + 0.0im
  000000000000000000000000000000000000000000000000000011101100 ₍₂₎   2.0 + 0.0im
  000000000000000000000000000000000000000000000000000011110010 ₍₂₎   2.0 + 0.0im
  000000000000000000000000000000000000000000000000000101101010 ₍₂₎   2.0 + 0.0im


julia> h[BitStr{60}(235),BitStr{60}(234)]
0.0 + 0.0im
```

## AbstractAdd

    AbstractAdd{D} <: CompositeBlock{D}

The abstract add interface, aimed to support Hamiltonian types.

### Required Interfaces
* `chsubblocks`
* `subblocks`

### Provides
* `unsafe_apply!` and its backward
* `mat` and its backward
* `adjoint`
* `occupied_locs`
* `getindex` over dit strings
* `ishermitian`