### PR TITLE
specify matblock printing

### DIFF
--- a/lib/YaoBlocks/src/layout.jl
+++ b/lib/YaoBlocks/src/layout.jl
@@ -209,7 +209,7 @@ print_block(io::IO, c::CachedBlock) = print_block(io, content(c))
 print_block(io::IO, c::Add) = printstyled(io, "+"; bold = true, color = color(Add))
 print_block(io::IO, c::TagBlock) = nothing
 print_block(io::IO, c::GeneralMatrixBlock) =
-    printstyled(io, "matblock(...)"; color = color(GeneralMatrixBlock))
+    printstyled(io, c.tag; color = color(GeneralMatrixBlock))
 
 function print_block(io::IO, c::Measure{D,K,OT}) where {D,K,OT}
     strs = String[]

--- a/lib/YaoBlocks/src/primitive/general_matrix_gate.jl
+++ b/lib/YaoBlocks/src/primitive/general_matrix_gate.jl
@@ -2,28 +2,38 @@ export GeneralMatrixBlock, matblock
 
 """
     GeneralMatrixBlock{D, MT} <: PrimitiveBlock{D}
+    GeneralMatrixBlock{D}(m, n, A, tag="matblock(...)")
+    GeneralMatrixBlock(A; nlevel=2, tag="matblock(...)")
 
 General matrix gate wraps a matrix operator to quantum gates. This is the most
 general form of a quantum gate.
+
+### Arguments
+
+* `m` and `n` are the number of dits in row and column.
+* `A` is a matrix.
+* `tag` is the printed information.
+* `D` and `nlevel` are the number of levels in each qudit.
 """
 struct GeneralMatrixBlock{D,T,MT<:AbstractMatrix{T}} <: PrimitiveBlock{D}
     m::Int
     n::Int
     mat::MT
+    tag::String
 
-    function GeneralMatrixBlock{D}(m::Int, n::Int, A::MT) where {D,T,MT<:AbstractMatrix{T}}
+    function GeneralMatrixBlock{D}(m::Int, n::Int, A::MT, tag::String="matblock(...)") where {D,T,MT<:AbstractMatrix{T}}
         (D^m, D^n) == size(A) ||
             throw(DimensionMismatch("expect a $(D^m) x $(D^n) matrix, got $(size(A))"))
 
-        return new{D,T,MT}(m, n, A)
+        return new{D,T,MT}(m, n, A, tag)
     end
 end
 YaoAPI.nqudits(m::GeneralMatrixBlock) = m.n
 
-GeneralMatrixBlock(m::AbstractMatrix; nlevel=2) = GeneralMatrixBlock{nlevel}(logdi.(size(m), nlevel)..., m)
+GeneralMatrixBlock(m::AbstractMatrix; nlevel=2, tag="matblock(...)") = GeneralMatrixBlock{nlevel}(logdi.(size(m), nlevel)..., m, tag)
 
 """
-    matblock(m::AbstractMatrix; nlevel=2)
+    matblock(mat_or_block; nlevel=2, tag="matblock(...)")
 
 Create a [`GeneralMatrixBlock`](@ref) with a matrix `m`.
 
@@ -39,14 +49,8 @@ matblock(...)
     Instead of converting it to the default data type `ComplexF64`,
     this will return its contained matrix when calling `mat`.
 """
-matblock(m::AbstractMatrix; nlevel=2) = GeneralMatrixBlock(m; nlevel=nlevel)
-
-"""
-    matblock(m::AbstractMatrix; nlevel=2)
-
-Create a [`GeneralMatrixBlock`](@ref) with a matrix `m`.
-"""
-matblock(m::AbstractBlock{D}) where {D} = GeneralMatrixBlock(mat(m); nlevel=D)
+matblock(m::AbstractMatrix; nlevel=2, tag="matblock(...)") = GeneralMatrixBlock(m; nlevel, tag)
+matblock(m::AbstractBlock{D}; tag="matblock(...)") where {D} = GeneralMatrixBlock(mat(m); nlevel=D, tag)
 
 cache_key(m::GeneralMatrixBlock) = hash(m.mat)
 

--- a/src/EasyBuild/hamiltonians.jl
+++ b/src/EasyBuild/hamiltonians.jl
@@ -32,20 +32,20 @@ end
 
 # a 3 level hamiltonian
 function rydberg_chain(nbits::Int; Ω::Number=0.0, Δ::Real=0.0, V::Real=0.0, r::Real=0.0)
-    Pr = matblock(sparse([3], [3], [1.0+0im], 3, 3); nlevel=3)
+    Pr = matblock(sparse([3], [3], [1.0+0im], 3, 3); nlevel=3, tag="|r⟩⟨r|")
     Z1r = matblock(sparse([2, 3], [2, 3], [1.0+0im, -1.0], 3, 3); nlevel=3)
-    X1r = matblock(sparse([2, 3], [3, 2], [1.0+0im, 1.0], 3, 3); nlevel=3)
-    X01 = matblock(sparse([1, 2], [2, 1], [1.0+0im, 1.0], 3, 3); nlevel=3)
-    Y1r = matblock(sparse([3, 2], [2, 3], [1.0im, -1.0im], 3, 3); nlevel=3)
+    X1r = matblock(sparse([2, 3], [3, 2], [1.0+0im, 1.0], 3, 3); nlevel=3, tag="|1⟩⟨r| + |r⟩⟨1|")
+    X01 = matblock(sparse([1, 2], [2, 1], [1.0+0im, 1.0], 3, 3); nlevel=3, tag="|1⟩⟨0| + |0⟩⟨1|")
+    Y1r = matblock(sparse([3, 2], [2, 3], [1.0im, -1.0im], 3, 3); nlevel=3, tag="i|1⟩⟨0| - i|0⟩⟨1|")
     # single site term in {|1>, |r>}.
     h = Add(nbits; nlevel=3)
-    !iszero(Δ) && push!(h, (-Δ) * sum([put(nbits, i=>Pr) for i=1:nbits]))
+    !isapprox(Δ, 0; atol=1e-12) && push!(h, (-Δ) * sum([put(nbits, i=>Pr) for i=1:nbits]))
     #!iszero(Δ) && push!(h, (-Δ/2) * sum([put(nbits, i=>Z1r) for i=1:nbits]))
-    !iszero(real(Ω)) && push!(h, real(Ω)/2 * sum([put(nbits, i=>X1r) for i=1:nbits]))
-    !iszero(imag(Ω)) && push!(h, imag(Ω)/2 * sum([put(nbits, i=>Y1r) for i=1:nbits]))
+    !isapprox(real(Ω), 0; atol=1e-12) && push!(h, real(Ω)/2 * sum([put(nbits, i=>X1r) for i=1:nbits]))
+    !isapprox(imag(Ω), 0; atol=1e-12) && push!(h, imag(Ω)/2 * sum([put(nbits, i=>Y1r) for i=1:nbits]))
     # interaction
-    !iszero(V) && nbits > 1 && push!(h, V * sum([put(nbits, (i,i+1)=>kron(Pr, Pr)) for i=1:nbits-1]))
+    !isapprox(V, 0; atol=1e-12) && nbits > 1 && push!(h, V * sum([put(nbits, (i,i+1)=>kron(Pr, Pr)) for i=1:nbits-1]))
     # Raman term
-    !iszero(r) && push!(h, r * sum([put(nbits, i=>X01) for i=1:nbits]))
+    !isapprox(r, 0; atol=1e-12) && push!(h, r * sum([put(nbits, i=>X01) for i=1:nbits]))
     return h
 end

--- a/test/easybuild/hamiltonians.jl
+++ b/test/easybuild/hamiltonians.jl
@@ -38,6 +38,7 @@ end
     ξ = 3.90242
     h1 = rydberg_chain(nbits; Ω=Ω, Δ=Δf*Ω, V)
     h2 = rydberg_chain(nbits; Ω=Ω*exp(im*ξ), Δ=Δf*Ω, V)
+    @test ishermitian(h1) && ishermitian(h2)
     levine_pichler_pulse = chain(time_evolve(h1, 2τ), time_evolve(h2, 2τ))
     # half pulse drives |11> to |11>
     i, j = dit"01;3", dit"11;3"


### PR DESCRIPTION
## Example
```julia
julia> function rydberg_chain(nbits::Int; Ω::Number=0.0, Δ::Real=0.0, V::Real=0.0, r::Real=0.0)
              Pr = matblock(sparse([3], [3], [1.0+0im], 3, 3); nlevel=3, tag="|r⟩⟨r|")
              Z1r = matblock(sparse([2, 3], [2, 3], [1.0+0im, -1.0], 3, 3); nlevel=3)
              X1r = matblock(sparse([2, 3], [3, 2], [1.0+0im, 1.0], 3, 3); nlevel=3, tag="|1⟩⟨r| + |r⟩⟨1|")
              X01 = matblock(sparse([1, 2], [2, 1], [1.0+0im, 1.0], 3, 3); nlevel=3, tag="|1⟩⟨0| + |0⟩⟨1|")
              Y1r = matblock(sparse([3, 2], [2, 3], [1.0im, -1.0im], 3, 3); nlevel=3, tag="i|1⟩⟨0| - i|0⟩⟨1|")
              # single site term in {|1>, |r>}.
              h = Add(nbits; nlevel=3)
              !isapprox(Δ, 0; atol=1e-12) && push!(h, (-Δ) * sum([put(nbits, i=>Pr) for i=1:nbits]))
              #!iszero(Δ) && push!(h, (-Δ/2) * sum([put(nbits, i=>Z1r) for i=1:nbits]))
              !isapprox(real(Ω), 0; atol=1e-12) && push!(h, real(Ω)/2 * sum([put(nbits, i=>X1r) for i=1:nbits]))
              !isapprox(imag(Ω), 0; atol=1e-12) && push!(h, imag(Ω)/2 * sum([put(nbits, i=>Y1r) for i=1:nbits]))
              # interaction
              !isapprox(V, 0; atol=1e-12) && nbits > 1 && push!(h, V * sum([put(nbits, (i,i+1)=>kron(Pr, Pr)) for i=1:nbits-1]))
              # Raman term
              !isapprox(r, 0; atol=1e-12) && push!(h, r * sum([put(nbits, i=>X01) for i=1:nbits]))
              return h
          end

julia> h1 = rydberg_chain(2; Ω=Ω, Δ=Δf*Ω, V)
nqudits: 2
+
├─ [scale: -0.377371] +
│     ├─ put on (1)
│     │  └─ |r⟩⟨r|
│     └─ put on (2)
│        └─ |r⟩⟨r|
├─ [scale: 0.5] +
│     ├─ put on (1)
│     │  └─ |1⟩⟨r| + |r⟩⟨1|
│     └─ put on (2)
│        └─ |1⟩⟨r| + |r⟩⟨1|
└─ [scale: 1000.0] +
      └─ put on (1, 2)
         └─ kron
            ├─ 1=>|r⟩⟨r|
            └─ 2=>|r⟩⟨r|
```