### PR TITLE
fix ad error for abstract vector constructors

### DIFF
--- a/lib/YaoBlocks/src/autodiff/chainrules_patch.jl
+++ b/lib/YaoBlocks/src/autodiff/chainrules_patch.jl
@@ -176,12 +176,16 @@ function rrule(::typeof(copy), reg::AbstractArrayReg)
 end
 
 for (BT, BLOCKS) in [(:Add, :(outδ.list)) (:ChainBlock, :(outδ.blocks))]
-    for ST in [:AbstractVector, :Tuple]
-        @eval function rrule(::Type{BT}, source::$ST) where {BT<:$BT}
-            out = BT(source)
-            out, function (outδ)
-                return (NoTangent(), $ST($BLOCKS))
-            end
+    @eval function rrule(::Type{BT}, source::AbstractVector) where {BT<:$BT}
+        out = BT(source)
+        out, function (outδ)
+            return (NoTangent(), collect($BLOCKS))
+        end
+    end
+    @eval function rrule(::Type{BT}, source::Tuple) where {BT<:$BT}
+        out = BT(source)
+        out, function (outδ)
+            return (NoTangent(), ($BLOCKS...,))
         end
     end
     @eval function rrule(::Type{BT}, args::AbstractBlock...) where {BT<:$BT}


### PR DESCRIPTION
The `sum` and `put` constructors are still not properly supported.
Zygote dispatches these functions to incorrect backward rules.
I do not have time to fix all interfaces, after all, the AD engine should be able to figure out the incorrect backward rules specification.

@VarLad 