### PR TITLE
Clarified documentation of @const_gate by adding a description of the nlevel=D option

### DIFF
--- a/lib/YaoBlocks/src/primitive/const_gate_tools.jl
+++ b/lib/YaoBlocks/src/primitive/const_gate_tools.jl
@@ -1,8 +1,8 @@
 export @const_gate
 
 """
-    @const_gate <gate name> = <expr>
-    @const_gate <gate name>::<type> = <expr>
+    @const_gate <gate name> = <expr> [nlevel=2]
+    @const_gate <gate name>::<type> = <expr> [nlevel=2]
     @const_gate <gate>::<type>
 
 This macro simplify the definition of a constant gate. It will automatically bind the matrix form
@@ -12,12 +12,14 @@ to a constant which will reduce memory allocation in the runtime.
 
 ```julia
 @const_gate X = ComplexF64[0 1;1 0]
+@const_gate Sx = ComplexF64[0 1/√2 0; 1/√2 0 1/√2; 0 1/√2 0] nlevel=3
 ```
 
 or
 
 ```julia
 @const_gate X::ComplexF64 = [0 1;1 0]
+@const_gate Sx::ComplexF64 = [0 1/√2 0; 1/√2 0 1/√2; 0 1/√2 0] nlevel=3
 ```
 
 You can bind new element types by simply re-declare with a type annotation.


### PR DESCRIPTION
I had to read the sources to find out how to create a const_gate that acts on qutrits instead of qubits. To make it simpler for the next person I added some details to the docstring  of the const_gate macro.