### PR TITLE
fix type stability

### DIFF
--- a/lib/YaoBlocks/src/routines.jl
+++ b/lib/YaoBlocks/src/routines.jl
@@ -528,12 +528,13 @@ function instruct_get_column(::Type{T}, U, locs::NTuple{M}, cbits::NTuple{C}, cv
     # get the target element in U
     rows, vals = unsafe_getcol(T, U, DitStr{D,M,TI}(subj))
     # map rows
-    newrows = map(rows) do i
+    newrows = Vector{DitStr{D,L,TI}}(undef, length(rows))
+    for (idx, row) in enumerate(rows)
         subi = DitStr{D,L,TI}(j)
         @inbounds for ind in 1:M
             subi += BitBasis._lshift(Val{D}(), _takeat(buffer(i), Val{D}(), ind) - _takeat(subj, Val{D}(), ind), locs[ind]-1)
         end
-        subi
+        newrows[idx] = subi
     end
     return newrows, vals
 end

--- a/lib/YaoBlocks/src/routines.jl
+++ b/lib/YaoBlocks/src/routines.jl
@@ -532,7 +532,7 @@ function instruct_get_column(::Type{T}, U, locs::NTuple{M}, cbits::NTuple{C}, cv
     for (idx, row) in enumerate(rows)
         subi = DitStr{D,L,TI}(j)
         @inbounds for ind in 1:M
-            subi += BitBasis._lshift(Val{D}(), _takeat(buffer(i), Val{D}(), ind) - _takeat(subj, Val{D}(), ind), locs[ind]-1)
+            subi += BitBasis._lshift(Val{D}(), _takeat(buffer(row), Val{D}(), ind) - _takeat(subj, Val{D}(), ind), locs[ind]-1)
         end
         newrows[idx] = subi
     end

--- a/lib/YaoBlocks/test/rountines.jl
+++ b/lib/YaoBlocks/test/rountines.jl
@@ -65,3 +65,9 @@ end
     @test mat(put(3, 2 => G1')) ≈ mat(put(3, 2 => matblock(G1)))'
     @test mat(put(7, (3, 2, 1, 5, 4, 6) => G6')) ≈ mat(put(7, (3, 2, 1, 5, 4, 6) => G6))'
 end
+
+@testset "use routines" begin
+    rows, vals = YaoBlocks.unsafe_getcol(ComplexF64, put(5, 1=>ConstGate.P1), bit"00000")
+    @test eltype(rows) isa DitStr
+    @test eltype(cols) isa ComplexF64
+end

--- a/lib/YaoBlocks/test/rountines.jl
+++ b/lib/YaoBlocks/test/rountines.jl
@@ -68,6 +68,6 @@ end
 
 @testset "use routines" begin
     rows, vals = YaoBlocks.unsafe_getcol(ComplexF64, put(5, 1=>ConstGate.P1), bit"00000")
-    @test eltype(rows) isa DitStr
-    @test eltype(cols) isa ComplexF64
+    @test eltype(rows) <: DitStr
+    @test eltype(vals) <: ComplexF64
 end


### PR DESCRIPTION
MWE:

before

```julia
julia> using YaoBlocks, BitBasis
[ Info: Precompiling YaoBlocks [418bc28f-b43b-5e0b-a6e7-61bbc1a2c1df]

julia> YaoBlocks.unsafe_getcol(ComplexF64, put(5, 1=>ConstGate.P1), bit"00000")
(Any[], ComplexF64[])
```

after

```julia
julia> using YaoBlocks, BitBasis

julia> YaoBlocks.unsafe_getcol(ComplexF64, put(5, 1=>ConstGate.P1), bit"00000")
(DitStr{2, 5, Int64}[], ComplexF64[])
```