### PR TITLE
Changed expect_g and fidelity_g to return the "correctly" scaled gradient w.r.t to the register

### DIFF
--- a/lib/YaoBlocks/src/autodiff/chainrules_patch.jl
+++ b/lib/YaoBlocks/src/autodiff/chainrules_patch.jl
@@ -122,7 +122,7 @@ function rrule(
     function (outδ)
         reg, c = reg_and_circuit
         out = copy(reg) |> c
-        goutreg = copy(out) |> op
+        goutreg = 2copy(out) |> op
         for b = 1:YaoArrayRegister._asint(nbatch(goutreg))
             viewbatch(goutreg, b).state .*= outδ[b]
         end

--- a/lib/YaoBlocks/src/autodiff/chainrules_patch.jl
+++ b/lib/YaoBlocks/src/autodiff/chainrules_patch.jl
@@ -107,7 +107,7 @@ function rrule(::typeof(expect), op::AbstractBlock, reg::AbstractArrayReg)
     out, function (outδ)
         greg = expect_g(op, reg)
         for b = 1:B
-            viewbatch(greg, b).state .*= 2 * outδ[b]
+            viewbatch(greg, b).state .*= outδ[b]
         end
         return (NoTangent(), NoTangent(), greg)
     end
@@ -124,7 +124,7 @@ function rrule(
         out = copy(reg) |> c
         goutreg = copy(out) |> op
         for b = 1:YaoArrayRegister._asint(nbatch(goutreg))
-            viewbatch(goutreg, b).state .*= 2 * outδ[b]
+            viewbatch(goutreg, b).state .*= outδ[b]
         end
         # apply backward rule
         (in, greg), gcircuit = apply_back((out, goutreg), c)

--- a/lib/YaoBlocks/src/autodiff/specializes.jl
+++ b/lib/YaoBlocks/src/autodiff/specializes.jl
@@ -12,13 +12,13 @@ end
 function expect_g(op::AbstractBlock, circuit::Pair{<:AbstractArrayReg,<:AbstractBlock})
     reg, c = circuit
     out = copy(reg) |> c
-    outδ = copy(out) |> op
+    outδ = 2copy(out) |> op
     (in, inδ), paramsδ = apply_back((out, outδ), c)
-    return inδ => paramsδ .* 2
+    return inδ => paramsδ
 end
 
 function expect_g(op::AbstractBlock, reg::AbstractArrayReg)
-    copy(reg) |> op
+    2copy(reg) |> op
 end
 
 _eval(p::Pair{<:AbstractRegister,<:AbstractBlock}) = copy(p.first) |> p.second
@@ -61,20 +61,20 @@ please file an issue if you really need this feature.",
     overlap = out1' * out2
 
     out1δ = copy(out2)
-    regscale!.(viewbatch.(Ref(out1δ), 1:length(overlap)), conj.(overlap) ./ 2 ./ abs.(overlap))
+    regscale!.(viewbatch.(Ref(out1δ), 1:length(overlap)), conj.(overlap) ./ abs.(overlap))
     out2δ = copy(out1)
-    regscale!.(viewbatch.(Ref(out2δ), 1:length(overlap)), overlap ./ 2 ./ abs.(overlap))
+    regscale!.(viewbatch.(Ref(out2δ), 1:length(overlap)), overlap ./ abs.(overlap))
 
     if reg1 isa Pair
         (_, in1δ), params1δ = apply_back((out1, out1δ), c1)
-        res1 = in1δ => params1δ .* 2
+        res1 = in1δ => params1δ
     else
         res1 = out1δ
     end
 
     if reg2 isa Pair
         (_, in2δ), params2δ = apply_back((out2, out2δ), c2)
-        res2 = in2δ => params2δ .* 2
+        res2 = in2δ => params2δ
     else
         res2 = out2δ
     end

--- a/lib/YaoBlocks/test/autodiff/specializes.jl
+++ b/lib/YaoBlocks/test/autodiff/specializes.jl
@@ -18,7 +18,7 @@ function state_numgrad(f, reg)
         reg.state[i] -= 2e-5im
         ineg = f(reg)
         reg.state[i] += 1e-5im
-        ((pos - neg) + im * (ipos - ineg)) / 2e-5 / 2
+        ((pos - neg) + im * (ipos - ineg)) / 2e-5
     end
 end
 


### PR DESCRIPTION
Up until now `expect_g` and `fidelity_g` were off by a factor of one half, in the sense that 
∂_reg expect(ham, reg) = 2 * expect_g(ham, reg) instead ∂_reg expect(ham, reg) = expect_g(ham, reg) and analogous for the other methods of `expect_g` and `fidelity_g`. This was counter acted by multiplying a factor of 2 to the final `paramsδ` at the end of `expect_g(ham, reg => circuit)` and `fidelity_g(reg1 => circuit1, reg2 => circuit2)`.

This is changed here to backpropagate the "correctly" scaled gradient w.r.t registers.

I am not sure if this would be considered a breaking change, because it also means that the output of `expect'(ham, reg => circuit)[1]` is changed by a factor of 2 now. 


Changes: 
 - Changed expect_g and fidelity_g
 - Updated the rrules in chainrules_patch.jl
 - Updated the corresponding tests