### PR TITLE
Moved `qubit_type` to `YaoAPI`

### DIFF
--- a/lib/YaoAPI/src/registers.jl
+++ b/lib/YaoAPI/src/registers.jl
@@ -29,6 +29,14 @@ For qubits, `D = 2`.
 """
 abstract type AbstractRegister{D} end
 
+"""
+    qubit_type(::AbstractRegister{2})
+    qubit_type(::AbstractRegister)
+
+Return "qubit" or "qudit" for pretty printing of registers.
+"""
+qubit_type(::AbstractRegister{2}) = "qubits"
+qubit_type(::AbstractRegister) = "qudits"
 
 """
     AdjointRegister{D, RT<:AbstractRegister{D}} <: AbstractRegister{D}

--- a/lib/YaoArrayRegister/src/density_matrix.jl
+++ b/lib/YaoArrayRegister/src/density_matrix.jl
@@ -54,14 +54,9 @@ end
 
 completely_mixed_state(n::Int; nlevel::Int=2) = completely_mixed_state(ComplexF64, n; nlevel)
 
-# Move this to YaoAPI and dispatch on `AbstractRegister{D}`?
-# Could then remove from YaoArrayRegister/src/register.jl and here
-qubit_type(::DensityMatrix{2}) = "qubits"
-qubit_type(::DensityMatrix) = "qudits"
-
 function Base.show(io::IO, dm::DensityMatrix{D,T,MT}) where {D,T,MT}
     print(io, "DensityMatrix{$D, $T, $(nameof(MT))...}")
-    print(io, "\n    active $(qubit_type(dm)): ", nactive(dm), "/", nqudits(dm))
+    print(io, "\n    active $(YaoAPI.qubit_type(dm)): ", nactive(dm), "/", nqudits(dm))
     print(io, "\n    nlevel: ", nlevel(dm))
 end
 

--- a/lib/YaoArrayRegister/src/register.jl
+++ b/lib/YaoArrayRegister/src/register.jl
@@ -666,20 +666,15 @@ oneto(r::AbstractArrayReg{D,T,<:Transpose}, n::Int = nqudits(r)) where {D,T} =
 YaoAPI.clone(r::AbstractArrayReg{D}, n::Int) where D =
     BatchedArrayReg{D}(hcat((state(r) for k = 1:n)...), n * _asint(nbatch(r)))
 
-# NOTE: overload this to make printing more compact
-#       but do not alter the way how type parameters print
-qubit_type(::AbstractArrayReg{2}) = "qubits"
-qubit_type(::AbstractArrayReg) = "qudits"
-
 function Base.show(io::IO, reg::ArrayReg{D,T,MT}) where {D,T,MT}
     print(io, "ArrayReg{$D, $T, $(nameof(MT))...}")
-    print(io, "\n    active $(qubit_type(reg)): ", nactive(reg), "/", nqudits(reg))
+    print(io, "\n    active $(YaoAPI.qubit_type(reg)): ", nactive(reg), "/", nqudits(reg))
     print(io, "\n    nlevel: ", nlevel(reg))
 end
 
 function Base.show(io::IO, reg::BatchedArrayReg{D,T,MT}) where {D,T,MT}
     print(io, "BatchedArrayReg{$D, $T, $(nameof(MT))...}")
-    print(io, "\n    active $(qubit_type(reg)): ", nactive(reg), "/", nqudits(reg))
+    print(io, "\n    active $(YaoAPI.qubit_type(reg)): ", nactive(reg), "/", nqudits(reg))
     print(io, "\n    nlevel: ", nlevel(reg))
     print(io, "\n    nbatch: ", nbatch(reg))
 end


### PR DESCRIPTION
The title says it all. Only open question from me is, whether we want to export `qubit_type` as part of the general API of an `AbstractRegister`