### PR TITLE
Bumped compat for YaoArrayRegister because @assert_locs_inbound moved

### DIFF
--- a/lib/YaoBlocks/Project.toml
+++ b/lib/YaoBlocks/Project.toml
@@ -34,7 +34,7 @@ StaticArrays = "0.12, 1.0"
 StatsBase = "0.32, 0.33"
 TupleTools = "1.2"
 YaoAPI = "0.4"
-YaoArrayRegister = "0.9"
+YaoArrayRegister = "0.9.5"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
Currently both YaoBlocks v0.13.7 and YaoArrayRegister v0.9.5 export @assert_locs_inbound which results in warnings being thrown.

Additionally, many of the single qubit error channel only have the correct definition in this version.