### PR TITLE
Automatic benchmarking on pull requests

### DIFF
--- a/.github/workflows/benchmark_pr.yml
+++ b/.github/workflows/benchmark_pr.yml
@@ -1,0 +1,78 @@
+name: Benchmark a pull request
+
+on:
+  pull_request_target:
+    branches:
+      - master
+
+permissions:
+  pull-requests: write
+
+jobs:
+    generate_plots:
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v2
+            - uses: julia-actions/setup-julia@v1
+              with:
+                version: "1.8"
+            - uses: julia-actions/cache@v1
+            - name: Extract Package Name from Project.toml
+              id: extract-package-name
+              run: |
+                PACKAGE_NAME=$(grep "^name" Project.toml | sed 's/^name = "\(.*\)"$/\1/')
+                echo "::set-output name=package_name::$PACKAGE_NAME"
+            - name: Build AirspeedVelocity
+              env:
+                JULIA_NUM_THREADS: 2
+              run: |
+                # Lightweight build step, as sometimes the runner runs out of memory:
+                julia -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"]=0; import Pkg; Pkg.add(;url="https://github.com/MilesCranmer/AirspeedVelocity.jl.git")'
+                julia -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"]=0; import Pkg; Pkg.build("AirspeedVelocity")'
+            - name: Add ~/.julia/bin to PATH
+              run: |
+                echo "$HOME/.julia/bin" >> $GITHUB_PATH
+            - name: Run benchmarks
+              run: |
+                echo $PATH
+                ls -l ~/.julia/bin
+                mkdir results
+                benchpkg ${{ steps.extract-package-name.outputs.package_name }} --rev="${{github.event.repository.default_branch}},${{github.event.pull_request.head.sha}}" --url=${{ github.event.repository.clone_url }} --bench-on="${{github.event.pull_request.head.sha}}" --output-dir=results/ --tune
+            - name: Create plots from benchmarks
+              run: |
+                mkdir -p plots
+                benchpkgplot ${{ steps.extract-package-name.outputs.package_name }} --rev="${{github.event.repository.default_branch}},${{github.event.pull_request.head.sha}}" --npart=10 --format=png --input-dir=results/ --output-dir=plots/
+            - name: Upload plot as artifact
+              uses: actions/upload-artifact@v2
+              with:
+                name: plots
+                path: plots
+            - name: Create markdown table from benchmarks
+              run: |
+                benchpkgtable ${{ steps.extract-package-name.outputs.package_name }} --rev="${{github.event.repository.default_branch}},${{github.event.pull_request.head.sha}}" --input-dir=results/ --ratio > table.md
+                echo '### Benchmark Results' > body.md
+                echo '' >> body.md
+                echo '' >> body.md
+                cat table.md >> body.md
+                echo '' >> body.md
+                echo '' >> body.md
+                echo '### Benchmark Plots' >> body.md
+                echo 'A plot of the benchmark results have been uploaded as an artifact to the workflow run for this PR.' >> body.md
+                echo 'Go to "Actions"->"Benchmark a pull request"->[the most recent run]->"Artifacts" (at the bottom).' >> body.md
+
+            - name: Find Comment
+              uses: peter-evans/find-comment@v2
+              id: fcbenchmark
+              with:
+                issue-number: ${{ github.event.pull_request.number }}
+                comment-author: 'github-actions[bot]'
+                body-includes: Benchmark Results
+
+            - name: Comment on PR
+              uses: peter-evans/create-or-update-comment@v3
+              with:
+                comment-id: ${{ steps.fcbenchmark.outputs.comment-id }}
+                issue-number: ${{ github.event.pull_request.number }}
+                body-path: body.md
+                edit-mode: replace

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,0 +1,8 @@
+[deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+BitBasis = "50ba71b6-fa0f-514d-ae9a-0916efc90dcf"
+LuxurySparse = "d05aeea4-b7d4-55ac-b691-9e7fabb07ba2"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+PkgBenchmark = "32113eaa-f34f-5b0d-bd6c-c81e245fc73d"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -23,6 +23,7 @@ end
 module YaoArrayRegisterBenchmarks
     using ..BenchmarkUtils: replace_imports
     using Yao
+    using Yao.YaoBlocks: sprand_hermitian
     include(replace_imports, "../lib/YaoArrayRegister/benchmark/benchmarks.jl")
 end
 

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,18 @@
+using Yao
+using Yao: YaoArrayRegister, YaoBlocks
+
+module YaoArrayRegisterBenchmarks
+include("../lib/YaoArrayRegister/benchmark/benchmarks.jl")
+end
+
+module YaoBlocksBenchmarks
+include("../lib/YaoBlocks/benchmark/benchmarks.jl")
+end
+
+using BenchmarkTools
+import .YaoArrayRegisterBenchmarks: SUITE as yarSUITE
+import .YaoBlocksBenchmarks: SUITE as ybSUITE
+
+const SUITE = BenchmarkGroup()
+SUITE["YaoArrayRegister"] = yarSUITE
+SUITE["YaoBlocks"] = ybSUITE

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,12 +1,35 @@
-using Yao
-using Yao: YaoArrayRegister, YaoBlocks
+module BenchmarkUtils
+    """
+    Replace instances of, for example, `using YaoAPI` with `using Yao.YaoAPI`.
+    """
+    const libs = (:YaoAPI, :YaoArrayRegister, :YaoBlocks, :YaoSym)
+    function replace_imports(ex)
+        return _replace_imports(ex)
+    end
+    function _replace_imports(ex)
+        if isa(ex, Expr) && ex.head == :using
+            foreach(ex.args) do e
+                if isa(e, Expr) && first(e.args) in libs
+                    pushfirst!(e.args, :Yao)
+                end
+            end
+        elseif isa(ex, Expr)
+            map!(_replace_imports, ex.args, ex.args)
+        end
+        return ex
+    end
+end
 
 module YaoArrayRegisterBenchmarks
-include("../lib/YaoArrayRegister/benchmark/benchmarks.jl")
+    using ..BenchmarkUtils: replace_imports
+    using Yao
+    include(replace_imports, "../lib/YaoArrayRegister/benchmark/benchmarks.jl")
 end
 
 module YaoBlocksBenchmarks
-include("../lib/YaoBlocks/benchmark/benchmarks.jl")
+    using ..BenchmarkUtils: replace_imports
+    using Yao
+    include(replace_imports, "../lib/YaoBlocks/benchmark/benchmarks.jl")
 end
 
 using BenchmarkTools


### PR DESCRIPTION
This is an attempt to set up automatic benchmarking on every pull request to Yao.jl.

This PR creates a GitHub action that uses AirspeedVelocity.jl (easy benchmarking with a CLI based on Comonicon.jl) to automatically run the benchmarks file on all submitted PRs, and create a table of the performance measurements. This is useful for catching performance regressions.

Your project was a bit tricky to setup because there are multiple libraries in one repo. So, I created a main `benchmark/benchmarks.jl` file that `include`'s the benchmarks in the lib folders. This works as follows:

1. Wraps each library's benchmarks inside a module.
2. Creates a global `SUITE` with `SUITE["YaoArrayRegister"]` equal to the `YaoArrayRegister` benchmark suite, etc.
3. Uses a macro to replace all instances of e.g., `using YaoArrayRegister` with `using Yao.YaoArrayRegister` inside the included benchmarks, so that running the benchmark only requires `Yao` to be installed (easier to work with `AirspeedVelocity.jl`, as it will measure performance over the revision history of the git repo).

However, while it does seem to work at the import step, it seems like the benchmark files themselves are two years old and out-of-date. e.g., `sprand_hermitian` is no longer exported; there is some `instruct!` call that is no longer defined for the passed types, etc.

Please let me know how you'd like to proceed. e.g., perhaps you could update the API in the benchmarks file, and then this automated benchmarking could work? Feel free to push to this PR branch.

Cheers,
Miles

---

An example GitHub PR comment is shown here: https://github.com/SymbolicML/DynamicExpressions.jl/pull/27#issuecomment-1525571227

![image](https://user-images.githubusercontent.com/7593028/236714457-4a136eff-6ea1-43dd-a978-e92897eaab70.png)
