### PR TITLE
Fixed KronBlock equality check

### DIFF
--- a/lib/YaoBlocks/Project.toml
+++ b/lib/YaoBlocks/Project.toml
@@ -1,6 +1,6 @@
 name = "YaoBlocks"
 uuid = "418bc28f-b43b-5e0b-a6e7-61bbc1a2c1df"
-version = "0.13.8"
+version = "0.13.9"
 
 [deps]
 BitBasis = "50ba71b6-fa0f-514d-ae9a-0916efc90dcf"

--- a/lib/YaoBlocks/src/composite/kron.jl
+++ b/lib/YaoBlocks/src/composite/kron.jl
@@ -218,7 +218,7 @@ Base.length(k::KronBlock) = length(k.blocks)
 Base.eachindex(k::KronBlock) = k.locs
 
 function Base.:(==)(lhs::KronBlock, rhs::KronBlock)
-    return nqudits(lhs) == nqudits(rhs) && all(lhs.locs .== rhs.locs) && all(lhs.blocks .== rhs.blocks)
+    return nqudits(lhs) == nqudits(rhs) && length(lhs.locs) == length(rhs.locs) && all(lhs.locs .== rhs.locs) && all(lhs.blocks .== rhs.blocks)
 end
 
 Base.adjoint(blk::KronBlock) = KronBlock(blk.n, blk.locs, map(adjoint, blk.blocks))


### PR DESCRIPTION
Previously to this PR we had that 

```julia
using Yao
kb1 = kron(3, 1 => X)
kb2 = kron(3, 1=>X, 2=>Z)
kb3 = kron(3, 1=>X, 2=>Z, 3=>Y)
kb1 == kb2

# output 
false  # as one would expect

kb2 == kb3

# output
ERROR: DimensionMismatch: arrays could not be broadcast to a common size; got a dimension with lengths 2 and 3
```

This is fixed with this PR.