### PR TITLE
Include YaoPlots as a component package

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,6 +39,7 @@ jobs:
           - YaoArrayRegister
           - YaoBlocks
           - YaoSym
+          - YaoPlots
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ docs/src/assets/*.pdf
 *.synctex.gz
 *.fls
 *.log
+lib/YaoPlots/examples/*.png
+lib/YaoPlots/examples/*.svg

--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 YaoAPI = "0843a435-28de-4971-9e8b-a9641b2983a8"
 YaoArrayRegister = "e600142f-9330-5003-8abb-0ebd767abc51"
 YaoBlocks = "418bc28f-b43b-5e0b-a6e7-61bbc1a2c1df"
+YaoPlots = "32cfe2d9-419e-45f2-8191-2267705d8dbc"
 YaoSym = "3b27209a-d3d6-11e9-3c0f-41eb92b2cb9d"
 
 [compat]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -75,7 +75,7 @@ const PAGES = [
 indigo = DocThemeIndigo.install(Yao)
 
 makedocs(
-    modules = [Yao, YaoAPI, YaoArrayRegister, YaoBlocks, BitBasis, YaoSym, AD, Optimise],
+    modules = [Yao, YaoAPI, YaoArrayRegister, YaoBlocks, BitBasis, YaoSym, YaoPlots, AD, Optimise],
     format = Documenter.HTML(
         prettyurls = ("deploy" in ARGS),
         canonical = ("deploy" in ARGS) ? "https://docs.yaoquantum.org/" : nothing,
@@ -89,6 +89,7 @@ makedocs(
     sitename = "Documentation | Yao",
     linkcheck = !("skiplinks" in ARGS),
     pages = PAGES,
+    warnonly = [:missing_docs, :linkcheck, :cross_references],
 )
 
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,7 +2,7 @@ using Documenter
 using DocThemeIndigo
 using Literate
 using Yao
-using Yao: YaoBlocks, YaoArrayRegister, YaoSym, BitBasis, YaoAPI
+using Yao: YaoBlocks, YaoArrayRegister, YaoSym, BitBasis, YaoAPI, YaoPlots
 using YaoBlocks: AD
 using YaoBlocks: Optimise
 
@@ -63,6 +63,7 @@ const PAGES = [
         "man/registers.md",
         "man/blocks.md",
         "man/symbolic.md",
+        "man/plot.md",
         "man/automatic_differentiation.md",
         "man/simplification.md",
         "man/bitbasis.md",

--- a/docs/src/examples/1.prepare-ghz-state/index.md
+++ b/docs/src/examples/1.prepare-ghz-state/index.md
@@ -6,7 +6,7 @@ EditURL = "<unknown>/docs/src/quick-start/1.prepare-ghz-state/main.jl"
 [![](https://img.shields.io/badge/show-nbviewer-579ACA.svg)](<unknown>/generated//home/roger/code/julia/Yao/docs/src/quick-start/1.prepare-ghz-state/main.ipynb)
 [![](https://img.shields.io/badge/download-project-orange)](https://minhaskamal.github.io/DownGit/#/home?url=https://github.com/QuantumBFS/tutorials/tree/gh-pages/dev/generated//home/roger/code/julia/Yao/docs/src/quick-start/1.prepare-ghz-state)
 
-# [Prepare Greenberger–Horne–Zeilinger state with Quantum Circuit](@id example-ghz)
+# [Prepare Greenberger–Horne–Zeilinger state with Quantum Circuit](@id tutorial-ghz)
 
 First, you have to use this package in Julia.
 

--- a/docs/src/examples/2.qft-phase-estimation/main.jl
+++ b/docs/src/examples/2.qft-phase-estimation/main.jl
@@ -32,7 +32,7 @@ A(i, j) = control(i, j=>shift(2π/(1<<(i-j+1))))
 
 R4 = A(4, 1)
 
-# If you have read about [preparing GHZ state](@ref example-ghz),
+# If you have read about [preparing GHZ state](@ref tutorial-ghz),
 # you probably know that in Yao, we could just leave the number of qubits, and it
 # will be evaluated when possible.
 

--- a/docs/src/examples/6.quantum-circuit-born-machine/main.jl
+++ b/docs/src/examples/6.quantum-circuit-born-machine/main.jl
@@ -27,7 +27,7 @@ pg = gaussian_pdf(1:1<<6, 1<<5-0.5, 1<<4);
 
 # We can plot the distribution, it looks like
 
-plot(pg)
+Plots.plot(pg)
 
 # ## Create the Circuit
 
@@ -225,12 +225,12 @@ trained_pg = probs(zero_state(nqubits(qcbm)) |> qcbm)
 
 title!("training history")
 xlabel!("steps"); ylabel!("loss")
-plot(history)
+Plots.plot(history)
 
 # And let's check what we got
 
-fig2 = plot(1:1<<6, trained_pg; label="trained")
-plot!(fig2, 1:1<<6, pg; label="target")
+fig2 = Plots.plot(1:1<<6, trained_pg; label="trained")
+Plots.plot!(fig2, 1:1<<6, pg; label="target")
 title!("distribution")
 xlabel!("x"); ylabel!("p")
 

--- a/docs/src/examples/8.riemannian-gradient-flow/main.jl
+++ b/docs/src/examples/8.riemannian-gradient-flow/main.jl
@@ -42,8 +42,8 @@ for i in 1:100
     push!(history, real.(expect(h, zero_state(n)=>circuit)))
 end
 
-plot(history, legend=false)
-plot!(1:100, [w[1] for i=1:100])
+Plots.plot(history, legend=false)
+Plots.plot!(1:100, [w[1] for i=1:100])
 xlabel!("steps")
 ylabel!("energy")
 
@@ -134,8 +134,8 @@ for i=1:100
     push!(history, cost)
 end
 
-plot(history, legend=false)
-plot!(1:100, [w[1] for i=1:100])
+Plots.plot(history, legend=false)
+Plots.plot!(1:100, [w[1] for i=1:100])
 xlabel!("steps")
 ylabel!("energy")
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -26,7 +26,7 @@ The tutorials are written with [Literate](https://github.com/fredrikekre/Literat
 
 ## Pluto Notebooks
 
-There is also a set of Pluto notebooks available in [the notebooks folder](https://github.com/QuantumBFS/Yao.jl/notebooks)
+There is also a set of Pluto notebooks available in [the notebooks folder](notebooks)
 
 ## Manual
 

--- a/docs/src/man/bitbasis.md
+++ b/docs/src/man/bitbasis.md
@@ -1,4 +1,5 @@
 ```@meta
+CurrentModule = BitBasis
 DocTestSetup = quote
     using Yao
     using Yao: YaoBlocks, YaoArrayRegister

--- a/docs/src/man/blocks.md
+++ b/docs/src/man/blocks.md
@@ -1,4 +1,5 @@
 ```@meta
+CurrentModule = YaoBlocks
 DocTestSetup = quote
     using Yao
     using Yao: YaoBlocks, YaoArrayRegister
@@ -10,12 +11,18 @@ end
 # Blocks
 
 **Blocks** are the basic building blocks of a quantum circuit in Yao.
-It simply means a quantum operator, thus, all the blocks have matrices in principal and one can get its matrix by [`mat`](@ref). The basic blocks required to build an arbitrary quantum circuit is defined in the component package [`YaoBlocks`](@ref).
+It simply means a quantum operator, thus, all the blocks have matrices in principal and one can get its matrix by [`mat`](@ref). The basic blocks required to build an arbitrary quantum circuit is defined in the component package `YaoBlocks`.
 
 Block Tree serves as an intermediate representation for Yao to analysis, optimize the circuit, then it will be lowered to instructions like for simulations, blocks will be lowered to [`instruct!`](@ref) calls.
 
 The structure of blocks is the same with a small type system, it consists of two basic kinds of blocks: [`CompositeBlock`](@ref) (like composite types), and [`PrimitiveBlock`](@ref) (like primitive types). By combining these two kinds of blocks together, we'll be able to
 construct a quantum circuit and represent it in a tree data structure.
+
+```@docs
+AbstractBlock
+PrimitiveBlock
+CompositeBlock
+```
 
 ## Primitive Blocks
 
@@ -28,6 +35,10 @@ Modules = [YaoBlocks]
 Filter = t ->(t isa Type && t <: YaoBlocks.PrimitiveBlock)
 ```
 
+```@docs
+@const_gate
+```
+
 ## Composite Blocks
 
 Composite blocks are subtypes of [`CompositeBlock`](@ref), they are the composition of blocks.
@@ -37,6 +48,24 @@ We provide the following composite blocks:
 ```@autodocs
 Modules = [YaoBlocks]
 Filter = t -> t isa Type && t <: YaoBlocks.CompositeBlock
+```
+
+## Operations on Blocks
+```@docs
+unsafe_apply!
+apply!
+apply
+
+niparams
+getiparams
+render_params
+nparameters
+
+occupied_locs
+print_block
+
+apply_back!
+mat_back!
 ```
 
 ## Error and Exceptions

--- a/docs/src/man/plot.md
+++ b/docs/src/man/plot.md
@@ -1,0 +1,34 @@
+```@meta
+CurrentModule = YaoPlots
+DocTestSetup = quote
+    using Yao
+    using Yao: YaoBlocks, YaoArrayRegister, YaoSym
+    using YaoBlocks
+    using YaoArrayRegister
+    using YaoPlots
+end
+```
+
+# Quantum Circuit Visualization
+
+Quantum circuit visualization support for Yao.
+
+## Circuit Visualization
+```@docs
+vizcircuit
+plot
+```
+
+## Bloch Sphere Visualization
+
+```@docs
+CircuitStyles
+bloch_sphere
+BlochStyles
+```
+
+## Themes
+```@docs
+darktheme!
+lighttheme!
+```

--- a/docs/src/man/registers.md
+++ b/docs/src/man/registers.md
@@ -1,7 +1,9 @@
 ```@meta
+CurrentModule = YaoArrayRegister
 DocTestSetup = quote
     using Yao
-    using Yao: YaoBlocks, YaoArrayRegister
+    using BitBasis
+    using YaoAPI
     using YaoBlocks
     using YaoArrayRegister
 end
@@ -44,18 +46,17 @@ nqudits
 nqubits
 nactive
 nremain
-nbatch,
-nlevel,
+nbatch
+nlevel
 focus!
 focus
 relax!
-zero_state
 exchange_sysenv
 ```
 
 ## Storage
 
-Both [`ArayReg`](@reef) and [`BatchedArrayReg`](@ref) use matrices as the storage. For example, for a quantum register with ``a`` active qubits, ``r`` remaining qubits and batch size ``b``, the storage is as follows
+Both [`ArrayReg`](@ref) and [`BatchedArrayReg`](@ref) use matrices as the storage. For example, for a quantum register with ``a`` active qubits, ``r`` remaining qubits and batch size ``b``, the storage is as follows
 
 ![](../assets/images/regstorage.svg)
 
@@ -98,9 +99,9 @@ AdjointArrayReg
 
 We also have some faster inplace versions of arithematic operations
 ```@docs
-regadd!,
-regsub!,
-regscale!,
+regadd!
+regsub!
+regscale!
 ```
 
 We also define the following functions for state normalization, and distance measurement.
@@ -114,8 +115,8 @@ tracedist
 ## Resource management and addressing
 
 ```@docs
-add_qudits!
-add_qubits!
+insert_qudits!
+insert_qubits!
 append_qudits!
 append_qubits!
 reorder!
@@ -146,7 +147,7 @@ select!
 select
 collapseto!
 probs
-most_probable,
+most_probable
 ```
 
 ## Density matrices
@@ -158,6 +159,6 @@ rand_density_matrix
 completely_mixed_state
 partial_tr
 purify
-von_neumann_entropy,
-mutual_information,
+von_neumann_entropy
+mutual_information
 ```

--- a/docs/src/man/symbolic.md
+++ b/docs/src/man/symbolic.md
@@ -16,6 +16,5 @@ Symbolic Computation support for Yao
 ```@docs
 @ket_str
 @bra_str
-@vars
 szero_state
 ```

--- a/docs/src/quick-start.md
+++ b/docs/src/quick-start.md
@@ -24,7 +24,7 @@ the internal quantum state can be accessed via [`statevec`](@ref) method
 statevec(ghz_state(2))
 ```
 
-for more functionalities about registers please refer to the manual of [`registers`](@ref).
+for more functionalities about registers please refer to the manual of [Registers](@ref registers).
 
 ## Create quantum circuit with Yao blocks
 
@@ -80,15 +80,12 @@ Yao supports symbolic calculation of quantum circuit via `SymEngine`. We can sho
 
 ## Plot quantum circuits
 
-The [YaoPlots]() in Yao's ecosystem provides plotting for quantum circuits and ZX diagrams.
+The component package `YaoPlots` provides plotting for quantum circuits and ZX diagrams.
 
 ```@example quick-start
-using Yao.EasyBuild, YaoPlots
+using Yao.EasyBuild, Yao.YaoPlots
 using Compose
 
 # show a qft circuit
-Compose.SVG(plot(qft_circuit(5)))
+vizcircuit(qft_circuit(5))
 ```
-
-## Convert quantum circuits to tensor network
-## Simplify quantum circuit with ZX calculus

--- a/lib/YaoAPI/src/blocks.jl
+++ b/lib/YaoAPI/src/blocks.jl
@@ -3,7 +3,7 @@ export AbstractBlock, PrimitiveBlock, CompositeBlock, AbstractContainer, TagBloc
 const COMMON_OPTIONAL_METHODS = """
 - [`nlevel`](@ref).
 - [`getiparams`](@ref).
-- [`setiparams`](@ref).
+- [`setiparams!`](@ref).
 - [`parameters`](@ref).
 - [`nparameters`](@ref).
 - [`iparams_eltype`](@ref).
@@ -63,7 +63,7 @@ block can be decomposed into several primitive blocks.
 
 - [`nlevel`](@ref).
 - [`getiparams`](@ref).
-- [`setiparams`](@ref).
+- [`setiparams!`](@ref).
 - [`parameters`](@ref).
 - [`nparameters`](@ref).
 - [`iparams_eltype`](@ref).
@@ -94,7 +94,7 @@ as well.
 
 - [`nlevel`](@ref).
 - [`getiparams`](@ref).
-- [`setiparams`](@ref).
+- [`setiparams!`](@ref).
 - [`parameters`](@ref).
 - [`nparameters`](@ref).
 - [`iparams_eltype`](@ref).

--- a/lib/YaoAPI/src/registers.jl
+++ b/lib/YaoAPI/src/registers.jl
@@ -609,8 +609,8 @@ julia> reg |> probs
 
 Return the fidelity between two states.
 Calcuate the fidelity between `r1` and `r2`, if `r1` or `r2` is not pure state
-(`nactive(r) != nqudits(r)`), the fidelity is calcuated by purification. See also
-[`pure_state_fidelity`](@ref), [`purification_fidelity`](@ref).
+(`nactive(r) != nqudits(r)`), the fidelity is calcuated by purification. See also:
+http://iopscience.iop.org/article/10.1088/1367-2630/aa6a4b/meta
 
 Obtain the gradient with respect to registers and circuit parameters.
 For pair input `ψ=>circuit`, the returned gradient is a pair of `gψ=>gparams`,

--- a/lib/YaoArrayRegister/Project.toml
+++ b/lib/YaoArrayRegister/Project.toml
@@ -18,7 +18,7 @@ TupleTools = "9d95972d-f1c8-5527-a6e0-b4b365fa01f6"
 YaoAPI = "0843a435-28de-4971-9e8b-a9641b2983a8"
 
 [compat]
-Adapt = "3"
+Adapt = "3, 4"
 BitBasis = "0.8, 0.9"
 DocStringExtensions = "0.8, 0.9"
 LegibleLambdas = "0.3"

--- a/lib/YaoArrayRegister/src/register.jl
+++ b/lib/YaoArrayRegister/src/register.jl
@@ -1,5 +1,10 @@
 import BitBasis: BitStr, BitStr64
 
+"""
+    AbstractArrayReg
+
+Abstract type for quantum registers that are represented by an array.
+"""
 abstract type AbstractArrayReg{D,T,AT} <: AbstractRegister{D} end
 
 struct NoBatch end
@@ -26,8 +31,7 @@ is the numerical type for each amplitude, it is `ComplexF64` by default.
 !!! warning
 
     `ArrayReg` constructor will not normalize the quantum state. If you need a
-    normalized quantum state remember to use `normalize!(register)` on the register or
-    normalize the input raw array with `normalize` or [`batched_normalize!`](@ref).
+    normalized quantum state remember to use `normalize!(register)` on the register.
 """
 mutable struct ArrayReg{D,T,MT<:AbstractMatrix{T}} <: AbstractArrayReg{D,T,MT}
     state::MT
@@ -63,8 +67,7 @@ is the numerical type for each amplitude, it is `ComplexF64` by default.
 !!! warning
 
     `BatchedArrayReg` constructor will not normalize the quantum state. If you need a
-    normalized quantum state remember to use `normalize!(register)` on the register or
-    normalize the input raw array with `normalize` or [`batched_normalize!`](@ref).
+    normalized quantum state remember to use `normalize!(register)` on the register.
 """
 mutable struct BatchedArrayReg{D,T,MT<:AbstractMatrix{T}} <: AbstractArrayReg{D,T,MT}
     state::MT
@@ -145,6 +148,11 @@ end
 Adapt.@adapt_structure ArrayReg
 Adapt.@adapt_structure BatchedArrayReg
 
+"""
+    AdjointArrayReg{D,T,MT} = AdjointRegister{D,<:AbstractArrayReg{D,T,MT}}
+
+Adjoint array register type, it is used to represent the bra in the Dirac notation.
+"""
 const AdjointArrayReg{D,T,MT} = AdjointRegister{D,<:AbstractArrayReg{D,T,MT}}
 const ArrayRegOrAdjointArrayReg{D,T,MT} =
     Union{AbstractArrayReg{D,T,MT},AdjointArrayReg{D,T,MT}}
@@ -618,7 +626,7 @@ Create a uniform state:
 ```math
 \\frac{1}{\\sqrt{2^n}} \\sum_{k=0}^{2^{n}-1} |k\\rangle.
 ```
-This state can also be created by applying [`H`](@ref) (Hadmard gate) on ``|00⋯00⟩`` state.
+This state can also be created by applying `H` (Hadmard gate) on ``|00⋯00⟩`` state.
 
 ### Example
 

--- a/lib/YaoBlocks/src/abstract_block.jl
+++ b/lib/YaoBlocks/src/abstract_block.jl
@@ -339,7 +339,7 @@ render_params(r::AbstractBlock, ::Val{:zero}) =
 """
     cache_type(::Type) -> DataType
 
-Return the element type that a [`CacheFragment`](@ref)
+Return the element type that a `CacheFragment`
 will use.
 """
 cache_type(::Type{<:AbstractBlock}) = Any
@@ -420,7 +420,6 @@ end
 The non-inplace version of applying a block (of quantum circuit) to a quantum register.
 Check `apply!` for the faster inplace version.
 """
-# overwrite interface, this one avoids one copy
 function apply(reg::AbstractRegister{D}, block) where D
     return apply!(copy(reg), block)
 end

--- a/lib/YaoBlocks/src/composite/control.jl
+++ b/lib/YaoBlocks/src/composite/control.jl
@@ -1,5 +1,16 @@
 export ControlBlock, control, cnot, cz
 
+"""
+    $(TYPEDSIGNATURES)
+
+A control block is a composite block that applies a block when the control qubits are all ones.
+
+!!! note
+    If control qubit index is negative, it means the inverse control, i.e., the block is applied when the control qubit is zero.
+
+### Fields
+$(TYPEDFIELDS)
+"""
 struct ControlBlock{BT<:AbstractBlock,C,M} <: AbstractContainer{BT,2}
     n::Int
     ctrl_locs::NTuple{C,Int}

--- a/lib/YaoBlocks/src/composite/put_block.jl
+++ b/lib/YaoBlocks/src/composite/put_block.jl
@@ -119,7 +119,24 @@ function YaoAPI.iscommute(x::PutBlock{D}, y::PutBlock{D}) where {D}
     end
 end
 
+"""
+    Swap = PutBlock{2,2,G} where {G<:ConstGate.SWAPGate}
+    Swap(n::Int, locs::Tuple{Int,Int})
+
+Swap gate, which swaps two qubits.
+"""
 const Swap = PutBlock{2,2,G} where {G<:ConstGate.SWAPGate}
+
+"""
+    PSwap = PutBlock{2,2,RotationGate{2,T,G}} where {G<:ConstGate.SWAPGate}
+    PSwap(n::Int, locs::Tuple{Int,Int}, θ::Real)
+
+Parametrized swap gate that swaps two qubits with a phase, defined as
+
+```math
+{\\rm SWAP}(θ) = e^{-iθ{\\rm SWAP}/2}
+```
+"""
 const PSwap{T} = PutBlock{2,2,RotationGate{2,T,G}} where {G<:ConstGate.SWAPGate}
 Swap(n::Int, locs::Tuple{Int,Int}) = PutBlock(n, ConstGate.SWAPGate(), locs)
 PSwap(n::Int, locs::Tuple{Int,Int}, θ::Real) =

--- a/lib/YaoBlocks/src/layout.jl
+++ b/lib/YaoBlocks/src/layout.jl
@@ -77,7 +77,7 @@ Print the block tree.
 # Keywords
 
 - `maxdepth`: max tree depth to print
-- `charset`: default is ('├','└','│','─'). See also [`BlockTreeCharSet`](@ref).
+- `charset`: default is ('├','└','│','─'). See also `YaoBlocks.BlockTreeCharSet`.
 - `title`: control whether to print the title, `true` or `false`, default is `true`
 """
 function print_tree(

--- a/lib/YaoBlocks/src/primitive/reflect.jl
+++ b/lib/YaoBlocks/src/primitive/reflect.jl
@@ -1,18 +1,22 @@
 export ReflectGate, reflect
 
-ReflectGate{D, T, Tt, AT<:AbstractArrayReg{D, T}} = TimeEvolution{D,Tt,Projector{D,T,AT}}
-
 """
-$(TYPEDSIGNATURES)
+    ReflectGate{D, T, Tt, AT<:AbstractArrayReg{D, T}} = TimeEvolution{D,Tt,Projector{D,T,AT}}
 
-Create a [`ReflectGate`](@ref) with respect to an quantum state vector `v`.
-It defines the following gate operation.
+Let `|v⟩` be a quantum state vector, a reflection gate is a unitary operator that defined as the following operation.
 
 ```math
 |v⟩ → 1 - (1-exp(-iθ)) |v⟩⟨v|
 ```
 
 When ``θ = π``, it defines a standard reflection gate ``1-2|v⟩⟨v|``.
+"""
+ReflectGate{D, T, Tt, AT<:AbstractArrayReg{D, T}} = TimeEvolution{D,Tt,Projector{D,T,AT}}
+
+"""
+$(TYPEDSIGNATURES)
+
+Create a [`ReflectGate`](@ref) with respect to an quantum state vector `v`.
 
 ### Example
 

--- a/lib/YaoBlocks/src/treeutils/optimise.jl
+++ b/lib/YaoBlocks/src/treeutils/optimise.jl
@@ -214,7 +214,7 @@ const __default_simplification_rules__ =
     simplify(block[; rules=__default_simplification_rules__])
 
 Simplify a block tree accroding to given rules, default to use
-[`__default_simplification_rules__`](@ref).
+`YaoBlocks.Optimise.__default_simplification_rules__`.
 """
 function simplify(ex::AbstractBlock; rules = __default_simplification_rules__)
     out1 = simplify_pass(rules, ex)

--- a/lib/YaoPlots/Project.toml
+++ b/lib/YaoPlots/Project.toml
@@ -1,0 +1,24 @@
+name = "YaoPlots"
+uuid = "32cfe2d9-419e-45f2-8191-2267705d8dbc"
+version = "0.9.0"
+
+[deps]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Luxor = "ae8d54c2-7ccd-5906-9d76-62fc9837b5bc"
+Thebes = "8b424ff8-82f5-59a4-86a6-de3761897198"
+YaoArrayRegister = "e600142f-9330-5003-8abb-0ebd767abc51"
+YaoBlocks = "418bc28f-b43b-5e0b-a6e7-61bbc1a2c1df"
+
+[compat]
+LinearAlgebra = "1"
+Luxor = "3"
+Thebes = "1"
+YaoArrayRegister = "0.9"
+YaoBlocks = "0.13"
+julia = "1"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/lib/YaoPlots/README.md
+++ b/lib/YaoPlots/README.md
@@ -1,0 +1,61 @@
+# YaoPlots
+
+[![CI](https://github.com/QuantumBFS/YaoPlots.jl/actions/workflows/CI.yml/badge.svg)](https://github.com/QuantumBFS/YaoPlots.jl/actions/workflows/CI.yml)
+[![Coverage](https://codecov.io/gh/QuantumBFS/YaoPlots.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/QuantumBFS/YaoPlots.jl)
+
+## Example 1: Visualize a QBIR define in Yao
+
+```julia
+using Yao.EasyBuild, YaoPlots
+
+# show a qft circuit
+vizcircuit(qft_circuit(5))
+```
+
+If you are using a Pluto/Jupyter notebook, Atom/VSCode editor, you should see the following image in your plotting panel.
+
+![qft](examples/qft.png)
+
+## Example 2: Visualize a single qubit
+```julia
+using YaoPlots, Yao
+
+reg = zero_state(1) |> Rx(π/8) |> Rx(π/8)
+rho = density_matrix(ghz_state(2), 1)
+
+bloch_sphere("|ψ⟩"=>reg, "ρ"=>rho; show_projection_lines=true)
+```
+
+Similarly, you will see
+![bloch](examples/bloch.png)
+
+See more [examples](examples/circuits.jl).
+
+### Adjusting the plot attributes
+
+Various attributes of the visualizations can be altered. 
+The plot can be modified, if we change the following attributes
+
+- `YaoPlots.CircuitStyles.linecolor[]` for line color, default value being `"#000000"` (black color)
+- `YaoPlots.CircuitStyles.gate_bgcolor[]` for background color of square blocks, the default value being `"#FFFFFF"` (white color)
+- `YaoPlots.CircuitStyles.textcolor[]` for text color, default value being `"#000000`
+- `YaoPlots.CircuitStyles.lw[]` for line width, default value being `1` (pt)
+- `YaoPlots.CircuitStyles.textsize[]` for text size, default value being `16` (pt)
+- `YaoPlots.CircuitStyles.paramtextsize[]` for parameter text size, for parameterized gates, default value being `10` (pt)
+
+For example,
+
+```julia
+using YaoPlots, Yao
+YaoPlots.CircuitStyles.linecolor[] = "pink" 
+YaoPlots.CircuitStyles.gate_bgcolor[] = "yellow" 
+YaoPlots.CircuitStyles.textcolor[] = "#000080" # the navy blue color
+YaoPlots.CircuitStyles.fontfamily[] = "JuliaMono"
+YaoPlots.CircuitStyles.lw[] = 2.5
+YaoPlots.CircuitStyles.textsize[] = 13
+YaoPlots.CircuitStyles.paramtextsize[] = 8
+		
+vizcircuit(chain(3, put(1=>X), repeat(3, H), put(2=>Y), repeat(3, Rx(π/2))))
+```
+
+![attribute_example_2](examples/attr_circuit_2.svg)

--- a/lib/YaoPlots/examples/bloch.jl
+++ b/lib/YaoPlots/examples/bloch.jl
@@ -1,0 +1,54 @@
+using YaoPlots, Yao
+using LinearAlgebra: axpy!
+
+function commutator(x, y; ishermitian=false)
+    res = x * y
+    if ishermitian
+        return res - res'
+    else
+        return res - y * x
+    end
+end
+function anticommutator(x, y; ishermitian=false)
+    res = x * y
+    if ishermitian
+        return res + res'
+    else
+        return res + y * x
+    end
+end
+
+# single step master equation
+function mestep(rho::DensityMatrix{D}, h, Ls, dt) where D
+    res = copy(rho.state)
+    # The im*[ρ, H] term.
+    # NOTE: transposed storage is faster
+    reg = arrayreg(copy(rho.state)'; nlevel=size(rho.state, 2))
+    apply!(reg, h)
+    axpy!(dt * im, reg.state' - reg.state, res)
+    for L in Ls
+        # the LρL' term
+        axpy!(dt, apply(rho, L).state, res)
+        # the -(ρL'L + L'Lρ)/2 term
+        reg = arrayreg(copy(rho.state)'; nlevel=size(rho.state, 2))
+        apply!(reg, L' * L)
+        axpy!(-0.5dt, reg.state, res)
+        axpy!(-0.5dt, reg.state', res)
+    end
+    return DensityMatrix(res)
+end
+
+function simulate(t; dt=0.02, dissiplation=0.2, filename=nothing)
+    reg0 = zero_state(1) |> H
+    rho = density_matrix(reg0)
+    h = Z    # rotate around Z
+    Ls = [sqrt(dissiplation) * ConstGate.Pd]  # dissipation
+    states = ["|+⟩"=>rho]
+    for t = 0:dt:t
+        rho = mestep(rho, h, Ls, dt)
+        push!(states, ""=>rho)
+    end
+    return bloch_sphere(states...; filename)
+end
+
+simulate(π/2; filename=joinpath(@__DIR__, "mesolve.png"))

--- a/lib/YaoPlots/examples/circuits.jl
+++ b/lib/YaoPlots/examples/circuits.jl
@@ -1,0 +1,50 @@
+using Yao.EasyBuild, YaoPlots, Yao
+
+lighttheme!()
+YaoPlots.CircuitStyles.gate_bgcolor[] = "white"  # default is transparent
+# qft circuit
+vizcircuit(qft_circuit(5); filename=joinpath(@__DIR__, "qft.png"))
+
+# labeled and time evolution
+vizcircuit(chain(control(5, 3, (2,4)=>matblock(rand_unitary(4); tag="label")),
+    put(5, (2,4)=>matblock(rand_unitary(4); tag="labellabel")), time_evolve(+(put(5, 2=>X), kron(5, 2=>Z, 3=>Y)), 0.2)), filename=joinpath(@__DIR__, "labelled.png"))
+
+# variational circuit
+vizcircuit(variational_circuit(5), filename=joinpath(@__DIR__, "variational.png"))
+# vizcircuit(variational_circuit(5; mode=:Merged))
+
+# general U4 gate
+vizcircuit(general_U4(), filename=joinpath(@__DIR__, "u4.png"))
+
+# quantum supremacy circuit
+vizcircuit(rand_supremacy2d(2, 2, 8), filename=joinpath(@__DIR__, "supremacy2d.png"))
+
+# google 52 qubit
+vizcircuit(rand_google53(5); filename=joinpath(@__DIR__, "google53.png"))
+
+# control blocks
+vizcircuit(chain(control(5, (2,-3), 4=>X), control(5, (-4, -2), 1=>Z)), filename=joinpath(@__DIR__, "controls.png"))
+
+# controlled kron
+vizcircuit(control(4, 2, (1, 3)=>kron(X, X)), filename=joinpath(@__DIR__, "cxx.png"))
+
+vizcircuit(control(4, -collect(1:4-1), 4=>-Z), filename=joinpath(@__DIR__, "reflect.png"))
+
+vizcircuit(chain(5, [put(5, 2=>X), Yao.Measure(5; locs=(2,3)), Yao.Measure(5;locs=(2,)), Yao.Measure(5; resetto=bit"00110")]), filename=joinpath(@__DIR__, "measure.png"))
+
+vizcircuit(chain(5, [put(5, 2=>ConstGate.Sdag), put(5, 3=>ConstGate.Tdag),
+    put(5, (2,3)=>ConstGate.CNOT), put(5, (1,4)=>ConstGate.CZ), put(5, (1,2,5)=>ConstGate.Toffoli),
+    put(5, (2,3)=>ConstGate.SWAP), put(5, (1,)=>ConstGate.P0), put(5, (1,)=>ConstGate.I2),
+    put(5, (2,)=>ConstGate.P1), put(5, (1,)=>ConstGate.Pu), put(5, (1,)=>ConstGate.Pd),
+    put(5, (2,)=>ConstGate.T),
+    put(5, (2,)=>phase(0.4π)),
+    put(5, (2,)=>shift(0.4π)),
+    ]), filename=joinpath(@__DIR__, "constgates.png"))
+
+vizcircuit(chain(5, [put(5, (2,3)=>matblock(Matrix(SWAP), tag="SWAP")'), put(5, 2=>matblock(mat(I2), tag="id")), put(5, 2=>addlabel(X, "Xr")), control(5, (5,3), (2,4,1)=>put(3, (1,3)=>addlabel(SWAP, "SWAP")))]), filename=joinpath(@__DIR__, "multiqubit.png"))
+
+YaoPlots.darktheme!()
+YaoPlots.CircuitStyles.gate_bgcolor[] = "transparent"  # default is transparent
+# qft circuit
+vizcircuit(qft_circuit(5), filename=joinpath(@__DIR__, "qft-white.png"))
+

--- a/lib/YaoPlots/examples/rotation_gates.jl
+++ b/lib/YaoPlots/examples/rotation_gates.jl
@@ -1,0 +1,7 @@
+using Yao, YaoPlots, Yao.EasyBuild
+N = 4
+d = 1
+ising(nbit, i, j) = rot(kron(nbit, i=>X, j=>X), 0.0)
+circuit = dispatch!(variational_circuit(N, d, pair_ring(N), entangler=ising), :zero)
+
+circuit |> vizcircuit(scale=0.7)

--- a/lib/YaoPlots/src/YaoPlots.jl
+++ b/lib/YaoPlots/src/YaoPlots.jl
@@ -1,0 +1,22 @@
+module YaoPlots
+
+using YaoBlocks
+import Luxor
+import Thebes
+using Luxor: @layer, Point
+using Thebes: Point3D, project
+using YaoBlocks.DocStringExtensions
+using LinearAlgebra: tr
+
+export CircuitStyles, CircuitGrid, circuit_canvas, vizcircuit, darktheme!, lighttheme!
+export bloch_sphere, BlochStyles
+export plot
+
+plot(;kwargs...) = x->plot(x;kwargs...)
+plot(blk::AbstractBlock; kwargs...) = vizcircuit(blk; kwargs...)
+
+include("helperblock.jl")
+include("vizcircuit.jl")
+include("bloch.jl")
+
+end

--- a/lib/YaoPlots/src/YaoPlots.jl
+++ b/lib/YaoPlots/src/YaoPlots.jl
@@ -1,17 +1,19 @@
 module YaoPlots
 
 using YaoBlocks
+using YaoBlocks.DocStringExtensions
+using YaoArrayRegister
 import Luxor
 import Thebes
 using Luxor: @layer, Point
 using Thebes: Point3D, project
-using YaoBlocks.DocStringExtensions
 using LinearAlgebra: tr
 
-export CircuitStyles, CircuitGrid, circuit_canvas, vizcircuit, darktheme!, lighttheme!
+export CircuitStyles, vizcircuit, darktheme!, lighttheme!
 export bloch_sphere, BlochStyles
 export plot
 
+"""An alias of `vizcircuit`"""
 plot(;kwargs...) = x->plot(x;kwargs...)
 plot(blk::AbstractBlock; kwargs...) = vizcircuit(blk; kwargs...)
 

--- a/lib/YaoPlots/src/bloch.jl
+++ b/lib/YaoPlots/src/bloch.jl
@@ -1,0 +1,254 @@
+module BlochStyles
+    using Luxor
+    # generic config
+    const lw = Ref(1.0)
+    const textsize = Ref(16.0)
+    const fontfamily = Ref("monospace")
+    const background_color = Ref("transparent")
+    const color = Ref("#000000")
+
+    # bloch sphere config
+    const ball_size = Ref(100)
+    const dot_size = Ref(3)
+    const eye_point = Ref((500, 200, 200))
+
+    # axes config
+    const axes_lw = Ref(1.0)
+    const axes_colors = ["#000000", "#000000", "#000000"]
+    const axes_texts = ["x", "y", "z"]
+
+    # state display config
+    const show_projection_lines = Ref(false)
+    const show_angle_texts = Ref(false)
+    const show_line = Ref(true)
+    const show01 = Ref(false)
+end
+
+"""
+$TYPEDSIGNATURES
+
+Draw a bloch sphere, with the inputs being a list of `string => state` pairs,
+where the string is a label for the state and a state can be a complex vector of size 2, a Yao register or `DensityMatrix`.
+If you want to get a raw drawing, use `draw_bloch_sphere` instead.
+
+### Keyword Arguments
+Note: The default values can be specified in submodule `BlochStyles`.
+
+- `textsize`: the size of the text
+- `color`: the color of the drawing
+- `drawing_size`: the size of the drawing
+- `offset_x`: the offset of the drawing in x direction
+- `offset_y`: the offset of the drawing in y direction
+- `filename`: the filename of the output file, if not specified, a temporary file will be used
+- `format`: the format of the output file, if not specified, the format will be inferred from the filename
+- `fontfamily`: the font family of the text
+- `background_color`: the background color of the drawing
+- `lw`: the line width of the drawing
+- `eye_point`: the eye point of the drawing
+- `extra_kwargs`: extra keyword arguments passed to `draw_bloch_sphere`
+    - `dot_size`: the size of the dot
+    - `ball_size`: the size of the ball
+    - `show_projection_lines`: whether to show the projection lines
+    - `show_angle_texts`: whether to show the angle texts
+    - `show_line`: whether to show the line
+    - `show01`: whether to show the 0 and 1 states
+    - `colors`: the colors of the states
+    - `axes_lw`: the line width of the axes
+    - `axes_textsize`: the size of the axes texts
+    - `axes_colors`: the colors of the axes
+    - `axes_texts`: the texts of the axes
+
+### Examples
+
+```jldoctest
+julia> using YaoPlots, YaoBlocks, Luxor
+
+julia> bloch_sphere("|ψ⟩"=>rand_state(1), "ρ"=>density_matrix(rand_state(2), 1));
+```
+"""
+function bloch_sphere(states...;
+        textsize=BlochStyles.textsize[],
+        color = BlochStyles.color[],
+        drawing_size = 300,
+        offset_x = 0,
+        offset_y = 0,
+        filename = nothing,
+        format = :svg,
+        fontfamily = BlochStyles.fontfamily[],
+        background_color = BlochStyles.background_color[],
+        lw = BlochStyles.lw[],
+        eye_point = BlochStyles.eye_point[],
+        extra_kwargs...)
+
+    # file format
+    if filename === nothing
+        if format == :pdf
+            _format = tempname()*".pdf"
+        else
+            _format = format
+        end
+    else
+        _format = filename
+    end
+    # Set up the drawing canvas
+    Luxor.Drawing(drawing_size, drawing_size, _format)
+    Luxor.origin(drawing_size/2 + offset_x, drawing_size/2 + offset_y)
+    Luxor.background(background_color)
+    Luxor.sethue(color)
+    Luxor.fontsize(textsize)
+    fontfamily !== nothing && Luxor.fontface(fontfamily)
+    Luxor.setline(lw)
+    Thebes.eyepoint(eye_point...)
+
+    draw_bloch_sphere(states...; eye_point, extra_kwargs...)
+
+    # Save the drawing to a file
+    Luxor.finish()
+    Luxor.preview()
+end
+
+# draw bloch sphere at the origin
+function draw_bloch_sphere(states::Pair{<:AbstractString}...;
+        dot_size=BlochStyles.dot_size[],
+        ball_size=BlochStyles.ball_size[],
+        eye_point=BlochStyles.eye_point[],
+        show_projection_lines = BlochStyles.show_projection_lines[],
+        show_angle_texts = BlochStyles.show_angle_texts[],
+        show_line = BlochStyles.show_line[],
+        show01 = BlochStyles.show01[],
+        colors = fill(BlochStyles.color[], length(states)),
+        extra_kwargs...
+    )
+    # get coordinate of a state
+    getcoo(x) = Point3D(ball_size .* state_to_cartesian(x))
+
+    # ball
+    Luxor.circle(Point(0, 0), ball_size, :stroke)
+
+    # equator
+    nstep = 100
+    equator_points = map(LinRange(0, 2π*(1-1/nstep), nstep)) do ϕ
+        project(Point3D(ball_size .* polar_to_cartesian(1.0, π/2, ϕ)))
+    end
+    Luxor.line.(equator_points[1:2:end], equator_points[2:2:end], :stroke)
+
+    # show axes
+    axes3D(ball_size*3 ÷ 2; extra_kwargs...)
+
+    # show 01 states
+    if show01
+        for (txt, point) in [("|0⟩", [1, 0.0im]), ("|1⟩", [0.0im, 1])]
+            p = getcoo(point)
+            @layer begin
+                Luxor.sethue(BlochStyles.color[])
+                if Thebes.distance(Point3D(0, 0, 0), Point3D(eye_point...)) < Thebes.distance(p, Point3D(eye_point...))
+                    Luxor.setopacity(0.3)
+                end
+                show_point(txt, project(p); dot_size, text_offset=Point(10, 0), show_line=false)
+            end
+        end
+    end
+
+    # show points
+    for ((txt, point), color) in zip(states, colors)
+        p = getcoo(point)
+        @layer begin
+            Luxor.sethue(color)
+            if Thebes.distance(Point3D(0, 0, 0), Point3D(eye_point...)) < Thebes.distance(p, Point3D(eye_point...))
+                Luxor.setopacity(0.3)
+            end
+            show_point(txt, project(p); dot_size, text_offset=Point(10, 0), show_line=show_line)
+        end
+        if show_projection_lines
+            # show θ
+            ratio = 0.2
+            sz = project(Point3D(0, 0, ball_size*ratio))
+            if show_angle_texts
+                Luxor.move(sz)
+                Luxor.arc2r(Point(0, 0), sz, project(p) * ratio, :stroke)
+                Luxor.text("θ", sz - Point(0, ball_size*0.07))
+            end
+            # show equator projection and ϕ
+            equatorp = Point3D(p[1], p[2], 0)
+            sx = project(Point3D(ball_size*ratio, 0, 0))
+            
+            if show_angle_texts
+                Luxor.move(sx)
+                Luxor.carc2r(Point(0, 0), sx, project(equatorp) * ratio, :stroke)
+                Luxor.text("ϕ", sx - Point(ball_size*0.12, 0))
+            end
+
+            @layer begin
+                Luxor.setdash("dot")
+                Luxor.setline(1)
+                Luxor.line(project(p), project(equatorp), :stroke)
+                Luxor.line(Point(0, 0), project(equatorp), :stroke)
+            end
+        end
+    end
+end
+
+function show_point(txt, p; dot_size, text_offset, show_line)
+    Luxor.circle(p, dot_size, :fill)
+    Luxor.text(txt, p + text_offset)
+    show_line && Luxor.line(Point(0, 0), p, :stroke)
+end
+
+function polar_to_cartesian(r, θ, ϕ)
+    x = r * sin(θ) * cos(ϕ)
+    y = r * sin(θ) * sin(ϕ)
+    z = r * cos(θ)
+    return x, y, z
+end
+
+function cartesian_to_polar(x, y, z)
+    r = sqrt(x^2 + y^2 + z^2)
+    θ = acos(z/r)
+    ϕ = atan(y, x)
+    return r, θ, ϕ
+end
+
+function state_to_polar(state::AbstractVector{Complex{T}}) where T
+    @assert length(state) == 2
+    r = norm(state)
+    ϕ = iszero(state[1]) ? zero(T) : angle(state[2]/state[1])
+    θ = 2 * atan(abs(state[2]), abs(state[1]))
+    return r, θ, ϕ
+end
+state_to_cartesian(state) = polar_to_cartesian(state_to_polar(state)...)
+
+# Draw labelled 3D axes with length `n`.
+function axes3D(n::Int;
+        axes_lw = BlochStyles.axes_lw[],
+        axes_textsize = BlochStyles.textsize[],
+        axes_colors = BlochStyles.axes_colors,
+        axes_texts = BlochStyles.axes_texts,
+        )
+    @layer begin
+        Luxor.fontsize(axes_textsize)
+        Luxor.setline(axes_lw)
+        for i = 1:3
+            axis1 = project(Point3D(0.1, 0.1, 0.1))
+            axis2 = [0.1, 0.1, 0.1]
+            axis2[i] = n
+            axis2 = project(Point3D(axis2...))
+            Luxor.sethue(axes_colors[i])
+            if (axis1 !== nothing) && (axis2 !== nothing) && !isapprox(axis1, axis2)
+                Luxor.arrow(axis1, axis2)
+                Luxor.label(axes_texts[i], :N, axis2, offset=10)
+            end
+        end
+    end
+end
+
+# Interace to Yao
+function state_to_polar(reg::AbstractRegister{2})
+    @assert nqudits(reg) == 1 "Only single qubit register is allowed to plot on bloch sphere. If you want to plot a subsystem as a mixed state, please construct a density matrix first with `density_matrix`."
+    @assert nbatch(reg) == 1 || nbatch(reg) == YaoBlocks.NoBatch() "Only single batch register is allowed to plot on bloch sphere."
+    return state_to_polar(statevec(reg))
+end
+
+function state_to_cartesian(reg::DensityMatrix{2})
+    @assert nqudits(reg) == 1 "Only single qubit density matrix is allowed to plot on bloch sphere"
+    return real(tr(reg.state * mat(X))), real(tr(reg.state * mat(Y))), real(tr(reg.state * mat(Z)))
+end

--- a/lib/YaoPlots/src/bloch.jl
+++ b/lib/YaoPlots/src/bloch.jl
@@ -1,3 +1,37 @@
+"""
+    BlochStyles
+
+The module to define the default styles for bloch sphere drawing.
+To change the default styles, you can modify the values in this module, e.g.
+```julia
+using YaoPlots
+YaoPlots.BlochStyles.lw[] = 2.0
+```
+
+### Style variables
+#### Generic
+- `lw`: the line width of the drawing
+- `textsize`: the size of the text
+- `fontfamily`: the font family of the text
+- `background_color`: the background color of the drawing
+- `color`: the color of the drawing
+
+#### Sphere
+- `ball_size`: the size of the ball
+- `dot_size`: the size of the dot
+- `eye_point`: the eye point of the drawing
+
+#### Axis
+- `axes_lw`: the line width of the axes
+- `axes_colors`: the colors of the axes
+- `axes_texts`: the texts of the axes, default to `["x", "y", "z"]`
+
+#### State display
+- `show_projection_lines`: whether to show the projection lines
+- `show_angle_texts`: whether to show the angle texts
+- `show_line`: whether to show the line
+- `show01`: whether to show the 0 and 1 states
+"""
 module BlochStyles
     using Luxor
     # generic config
@@ -61,7 +95,7 @@ Note: The default values can be specified in submodule `BlochStyles`.
 ### Examples
 
 ```jldoctest
-julia> using YaoPlots, YaoBlocks, Luxor
+julia> using YaoPlots, YaoArrayRegister
 
 julia> bloch_sphere("|ψ⟩"=>rand_state(1), "ρ"=>density_matrix(rand_state(2), 1));
 ```

--- a/lib/YaoPlots/src/helperblock.jl
+++ b/lib/YaoPlots/src/helperblock.jl
@@ -1,0 +1,50 @@
+using YaoBlocks
+export LabelBlock
+
+"""
+    LabelBlock{BT,D} <: TagBlock{BT,D}
+
+A marker to mark a circuit applying on a continous block for better plotting.
+"""
+struct LabelBlock{BT<:AbstractBlock,D} <: TagBlock{BT,D}
+    content::BT
+    name::String
+end
+
+YaoBlocks.content(cb::LabelBlock) = cb.content
+function LabelBlock(x::BT, name::String) where {D,BT<:AbstractBlock{D}}
+    LabelBlock{BT,D}(x, name)
+end
+
+function is_continuous_chunk(x)
+    length(x) == 0 && return true
+    return length(x) == maximum(x)-minimum(x)+1
+end
+
+YaoBlocks.PropertyTrait(::LabelBlock) = YaoBlocks.PreserveAll()
+YaoBlocks.mat(::Type{T}, blk::LabelBlock) where {T} = mat(T, content(blk))
+YaoBlocks.unsafe_apply!(reg::YaoBlocks.AbstractRegister, blk::LabelBlock) = YaoBlocks.unsafe_apply!(reg, content(blk))
+YaoBlocks.chsubblocks(blk::LabelBlock, target::AbstractBlock) = LabelBlock(target, blk.name)
+
+Base.adjoint(x::LabelBlock) = LabelBlock(adjoint(content(x)), endswith(x.name, "†") ? x.name[1:end-1] : x.name*"†")
+Base.copy(x::LabelBlock) = LabelBlock(copy(content(x)), x.name)
+YaoBlocks.Optimise.to_basictypes(block::LabelBlock) = block
+
+export addlabel
+addlabel(b::AbstractBlock, str::String) = LabelBlock(b, str)
+
+# to fix issue 
+function YaoBlocks.print_tree(
+   io::IO,
+   root::AbstractBlock,
+   node::LabelBlock,
+   depth::Int = 1,
+   islast::Bool = false,
+   active_levels = ();
+   maxdepth = 5,
+   charset = YaoBlocks.BlockTreeCharSet(),
+   title = true,
+   compact = false,
+)
+   print(io, node.name)
+end

--- a/lib/YaoPlots/src/vizcircuit.jl
+++ b/lib/YaoPlots/src/vizcircuit.jl
@@ -1,0 +1,507 @@
+module CircuitStyles
+    using Luxor
+    const unit = Ref(60)    # number of points in a unit
+    const barrier_for_chain = Ref(false)
+    const r = Ref(0.2)
+    const lw = Ref(1.0)
+    const textsize = Ref(16.0)
+    const paramtextsize = Ref(10.0)
+    const fontfamily = Ref("monospace")
+    #const fontfamily = Ref("Dejavu Sans")
+    const linecolor = Ref("#000000")
+    const gate_bgcolor = Ref("transparent")
+    const textcolor = Ref("#000000")
+
+    abstract type Gadget end
+    struct Box{FT} <: Gadget
+        height::FT
+        width::FT
+    end
+    struct Cross <: Gadget end
+    struct Dot <: Gadget end
+    struct NDot <: Gadget end
+    struct OPlus <: Gadget end
+    struct MeasureBox <: Gadget end
+    struct Phase <: Gadget
+        text::String
+    end
+    struct Text{FT} <: Gadget
+        fontsize::FT
+    end
+    struct Line <: Gadget end
+    get_width(::Cross) = 0.0
+    get_width(::Phase) = r[]/2.5
+    get_width(::Dot) = r[]/2.5
+    get_width(::NDot) = r[]/2.5
+    get_width(::OPlus) = r[]*1.4
+    boxsize(b::Gadget) = (w = get_width(b); (w, w))
+    function boxsize(b::Box)
+        return b.width, b.height
+    end
+    function boxsize(::MeasureBox)
+        return 2 * r[], 2 * r[]
+    end
+
+    function render(b::Box, loc)
+        setcolor(gate_bgcolor[])
+        Luxor.box(Point(loc)*unit[], b.width*unit[], b.height*unit[], :fill)
+        setcolor(linecolor[])
+        setline(lw[])
+        Luxor.box(Point(loc)*unit[], b.width*unit[], b.height*unit[], :stroke)
+    end
+
+    function render(d::Dot, loc)
+        setcolor(linecolor[])
+        circle(Point(loc)*unit[], get_width(d)*unit[]/2, :fill)
+    end
+    function render(d::Phase, loc)
+        x0 = Point(loc)*unit[]
+        setcolor(linecolor[])
+        circle(x0, get_width(d)*unit[]/2, :fill)
+        setcolor(textcolor[])
+        fontsize(textsize[])
+        fontface(fontfamily[])
+        text(d.text, x0+Point(8,8); valign=:middle, halign=:center)
+    end
+    function render(d::NDot, loc)
+        setcolor(gate_bgcolor[])
+        circle(Point(loc)*unit[], get_width(d)*unit[]/2, :fill)
+        setcolor(linecolor[])
+        setline(lw[])
+        circle(Point(loc)*unit[], get_width(d)*unit[]/2, :stroke)
+    end
+    function render(::Cross, loc)
+        setline(lw[])
+        setcolor(linecolor[])
+        line(Point(loc[1]-r[]/sqrt(2), loc[2]-r[]/sqrt(2))*unit[], Point(loc[1]+r[]/sqrt(2), loc[2]+r[]/sqrt(2))*unit[], :stroke)
+        line(Point(loc[1]-r[]/sqrt(2), loc[2]+r[]/sqrt(2))*unit[], Point(loc[1]+r[]/sqrt(2), loc[2]-r[]/sqrt(2))*unit[], :stroke)
+    end
+    function render(d::OPlus, loc)
+        w = get_width(d) / 2
+        setcolor(gate_bgcolor[])
+        circle(Point(loc)*unit[], w*unit[], :fill)
+        setcolor(linecolor[])
+        setline(lw[])
+        x0 = Point(loc)*unit[]
+        circle(x0, w*unit[], :stroke)
+        line(x0+Point(-w*unit[], 0.0), x0+Point(w*unit[], 0.0*unit[]), :stroke)
+        line(x0+Point(0.0, -w*unit[]), x0+Point(0.0*unit[], w*unit[]), :stroke)
+    end
+    function render(::MeasureBox, loc)
+        x0 = Point(loc)*unit[]
+        setcolor(gate_bgcolor[])
+        box(x0, 2*r[]*unit[], 2*r[]*unit[], :fill)
+        setcolor(linecolor[])
+        setline(lw[])
+        box(x0, 2*r[]*unit[], 2*r[]*unit[], :stroke)
+        move(x0+Point(-0.8*r[], 0.5*r[])*unit[])
+        curve(
+            x0+Point(-0.8*r[], -0.6*r[])*unit[],
+            x0+Point(0.8*r[], -0.6*r[])*unit[],
+            x0+Point(0.8*r[], 0.5*r[])*unit[])
+        strokepath()
+        line(x0+Point(0.0, 0.5*r[])*unit[], x0+Point(0.7*r[], -0.4*r[])*unit[], :stroke)
+    end
+
+    function render(::Line, locs)
+        setcolor(linecolor[])
+        setline(lw[])
+        line(Point(locs[1])*unit[], Point(locs[2])*unit[], :stroke)
+    end
+    function render(t::Text, loctxt)
+        loc, txt, width, height = loctxt
+        fontsize(t.fontsize)
+        fontface(fontfamily[])
+        #fontface("Dejavu Sans")
+        setcolor(textcolor[])
+        if contains(txt, '\n')
+            for (i, txt) in enumerate(split(loctxt[2], "\n"))
+                text(txt, Point(loc)*unit[]+i*Point(0, t.fontsize)-Point((width-0.1)*unit[]/2, height*unit[]/2); halign=:left, valign=:middle)
+            end
+        else
+            text(txt, Point(loc)*unit[]; halign=:center, valign=:middle)
+        end
+    end
+
+    Base.@kwdef struct GateStyles
+        g = Box(2*r[], 2*r[])
+        c = Dot()
+        x = Cross()
+        nc = NDot()
+        not = OPlus()
+        measure = MeasureBox()
+
+        # other styles
+        line = Line()
+        text = Text(textsize[])
+        smalltext = Text(paramtextsize[])
+    end
+end
+
+struct CircuitGrid
+    frontier::Vector{Int}
+    w_depth::Float64
+    w_line::Float64
+    gatestyles::CircuitStyles.GateStyles
+end
+
+nline(c::CircuitGrid) = length(c.frontier)
+depth(c::CircuitGrid) = frontier(c, 1, nline(c))
+Base.getindex(c::CircuitGrid, i, j) = (c.w_depth*i, c.w_line*j)
+Base.typed_vcat(c::CircuitGrid, ij1, ij2) = (c[ij1...], c[ij2...])
+
+function CircuitGrid(nline::Int; w_depth=1.0, w_line=1.0, gatestyles=CircuitStyles.GateStyles())
+    CircuitGrid(zeros(Int, nline), w_depth, w_line, gatestyles)
+end
+
+function frontier(c::CircuitGrid, args...)
+    maximum(i->c.frontier[i], min(args..., nline(c)):max(args..., 1))
+end
+
+function _draw!(c::CircuitGrid, loc_brush_texts)
+    isempty(loc_brush_texts) && return
+    # a loc can be a integer, or a range
+    loc_brush_texts = sort(loc_brush_texts, by=x->maximum(x[1]))
+    locs = Iterators.flatten(getindex.(loc_brush_texts, 1)) |> collect
+
+    # get the gate width and the circuit depth to draw
+    boxwidths, boxheights = Float64[], Float64[]
+    loc_brush_texts = map(loc_brush_texts) do (j, b, txt)
+        if length(j) != 0
+            wspace, _ = text_width_and_size(txt)
+            hspace = (maximum(j)-minimum(j)) * c.w_line
+            # make box larger
+            b = b isa CircuitStyles.Box ? CircuitStyles.Box(b.height + hspace, b.width + wspace) : b
+            boxwidth, boxheight = CircuitStyles.boxsize(b)
+            push!(boxwidths, boxwidth)
+            push!(boxheights, boxheight)
+        end
+        (j, b, txt)
+    end
+    max_width = maximum(boxwidths)
+    ncolumn = max(1, ceil(Int, max_width/c.w_depth + 0.2))  # 0.1 is the minimum gap between two columns
+
+    ipre = frontier(c, minimum(locs):maximum(locs)...)
+    i = ipre + ncolumn/2
+    local jpre
+    for (k, ((j, b, txt), boxheight)) in enumerate(zip(loc_brush_texts, boxheights))
+        length(j) == 0 && continue
+        _, fontsize = text_width_and_size(txt)
+        jmid = (minimum(j)+maximum(j))/2
+        CircuitStyles.render(b, c[i, jmid])
+        CircuitStyles.render(CircuitStyles.Text(fontsize), (c[i,jmid], txt, CircuitStyles.boxsize(b)...))
+        # use line to connect blocks in the same gate
+        if k!=1
+            CircuitStyles.render(c.gatestyles.line, c[(i, jmid-boxheight/2/c.w_line); (i, jpre)])
+        end
+        jpre = jmid + boxheight/2/c.w_line
+    end
+
+    #jmin, jmax = min(locs..., nline(c)), max(locs..., 1)
+    # connect horizontal lines
+    for (width, (j, b, txt)) in zip(boxwidths, loc_brush_texts)
+        for jj in j
+            CircuitStyles.render(c.gatestyles.line, c[(c.frontier[jj], jj); (i-width/2/c.w_depth, jj)])
+            CircuitStyles.render(c.gatestyles.line, c[(i+width/2/c.w_depth, jj); (ipre+ncolumn, jj)])
+            c.frontier[jj] = ipre + ncolumn
+        end
+    end
+    for j in setdiff(minimum(locs):maximum(locs), locs)
+        CircuitStyles.render(c.gatestyles.line, c[(c.frontier[j], j); (ipre+ncolumn, j)])
+        c.frontier[j] = ipre + ncolumn
+    end
+end
+
+function text_width_and_size(text)
+    lines = split(text, "\n")
+    widths = map(x->textwidth(x), lines)
+    (mw, loc) = findmax(widths)
+    fontsize = mw > 3 ? CircuitStyles.paramtextsize[] : CircuitStyles.textsize[]
+    # -2 because the gate has a default size
+    #width = max(W - 4, 0) * fontsize * 0.016  # mm to cm
+    Luxor.fontsize(fontsize)
+    Luxor.fontface(CircuitStyles.fontfamily[])
+    width, height = Luxor.textextents(lines[loc])[3:4]
+    w = max(width / CircuitStyles.unit[] - CircuitStyles.r[]*2 + 0.2, 0.0)
+    return w, fontsize
+end
+
+function initialize!(c::CircuitGrid; starting_texts, starting_offset)
+    starting_texts !== nothing && for j=1:nline(c)
+        CircuitStyles.render(c.gatestyles.text, (c[starting_offset, j], string(starting_texts[j]), c.w_depth, c.w_line))
+    end
+end
+
+function finalize!(c::CircuitGrid; show_ending_bar, ending_offset, ending_texts)
+    i = frontier(c, 1, nline(c))
+    for j=1:nline(c)
+        show_ending_bar && CircuitStyles.render(c.gatestyles.line, c[(i, j-0.2); (i, j+0.2)])
+        CircuitStyles.render(c.gatestyles.line, c[(i, j); (c.frontier[j], j)])
+        ending_texts !== nothing && CircuitStyles.render(c.gatestyles.text, (c[i+ending_offset, j], string(ending_texts[j]), c.w_depth, c.w_line))
+    end
+end
+
+# elementary
+function draw!(c::CircuitGrid, p::PrimitiveBlock, address, controls)
+    bts = length(controls)>=1 ? get_cbrush_texts(c, p) : get_brush_texts(c, p)
+    _draw!(c, [controls..., (getindex.(Ref(address), occupied_locs(p)), bts[1], bts[2])])
+end
+function draw!(c::CircuitGrid, p::Daggered{<:PrimitiveBlock}, address, controls)
+    bts = length(controls)>=1 ? get_cbrush_texts(c, content(p)) : get_brush_texts(c, content(p))
+    _draw!(c, [controls..., (getindex.(Ref(address), occupied_locs(p)), bts[1], bts[2]*"'")])
+end
+
+function draw!(c::CircuitGrid, p::Scale, address, controls)
+    fp = YaoBlocks.factor(p)
+    if !(abs(fp) ≈ 1)
+        error("can not visualize non-phase factor.")
+    end
+    draw!(c, YaoBlocks.phase(angle(fp)), [first(address)], controls)
+    draw!(c, p.content, address, controls)
+end
+# Special primitive gates
+function draw!(c::CircuitGrid, ::I2Gate, address, controls)
+    return
+end
+function draw!(c::CircuitGrid, ::IdentityGate, address, controls)
+    return
+end
+function draw!(c::CircuitGrid, p::ConstGate.SWAPGate, address, controls)
+    bts = [(c.gatestyles.x, ""), (c.gatestyles.x, "")]
+    _draw!(c, [controls..., [(address[l], bt...) for (l, bt) in zip(occupied_locs(p), bts)]...])
+end
+function draw!(c::CircuitGrid, p::ConstGate.CNOTGate, address, controls)
+    bts = [(c.gatestyles.c, ""), (c.gatestyles.x, "")]
+    _draw!(c, [controls..., [(address[l], bt...) for (l, bt) in zip(occupied_locs(p), bts)]...])
+end
+function draw!(c::CircuitGrid, p::ConstGate.CZGate, address, controls)
+    bts = [(c.gatestyles.c, ""), (c.gatestyles.c, "")]
+    _draw!(c, [controls..., [(address[l], bt...) for (l, bt) in zip(occupied_locs(p), bts)]...])
+end
+function draw!(c::CircuitGrid, p::ConstGate.ToffoliGate, address, controls)
+    bts = [(c.gatestyles.c, ""), (c.gatestyles.c, ""), (c.gatestyles.x, "")]
+    _draw!(c, [controls..., [(address[l], bt...) for (l, bt) in zip(occupied_locs(p), bts)]...])
+end
+
+# composite
+function draw!(c::CircuitGrid, p::ChainBlock, address, controls)
+    for block in subblocks(p)
+        draw!(c, block, address, controls)
+        CircuitStyles.barrier_for_chain[] && set_barrier!(c, Int[address..., controls...])
+    end
+end
+
+function set_barrier!(c::CircuitGrid, locs::AbstractVector{Int})
+    front = maximum(c.frontier[locs])
+    for loc in locs
+        if c.frontier[loc] < front
+            CircuitStyles.render(c.gatestyles.line, c[(c.frontier[loc], loc); (front, loc)])
+            c.frontier[loc] = front
+        end
+    end
+end
+
+function draw!(c::CircuitGrid, p::PutBlock, address, controls)
+    locs = [address[i] for i in p.locs]
+    draw!(c, p.content, locs, controls)
+end
+
+function draw!(c::CircuitGrid, m::YaoBlocks.Measure, address, controls)
+    @assert length(controls) == 0
+    if m.postprocess isa RemoveMeasured
+        error("can not visualize post-processing: `RemoveMeasured`.")
+    end
+    if !(m.operator isa ComputationalBasis)
+        error("can not visualize measure blocks for operators")
+    end
+    locs = m.locations isa AllLocs ? collect(1:nqudits(m)) : [address[i] for i in m.locations]
+    for (i, loc) in enumerate(locs)
+        _draw!(c, [(loc, c.gatestyles.measure, "")])
+        if m.postprocess isa ResetTo
+            # read i-th bit value
+            val = Int(m.postprocess.x)>>(i-1) & 1
+            _draw!(c, [(loc, c.gatestyles.g, val == 1 ? "P₁" : "P₀")])
+        end
+    end
+end
+
+function draw!(c::CircuitGrid, cb::ControlBlock{GT,C}, address, controls) where {GT,C}
+    ctrl_locs = [address[i] for i in cb.ctrl_locs]
+    locs = [address[i] for i in cb.locs]
+    mycontrols = [(loc, (bit == 1 ? c.gatestyles.c : c.gatestyles.nc), "") for (loc, bit)=zip(ctrl_locs, cb.ctrl_config)]
+    draw!(c, cb.content, locs, [controls..., mycontrols...])
+end
+
+for B in [:LabelBlock, :GeneralMatrixBlock, :Add]
+    @eval function draw!(c::CircuitGrid, cb::$B, address, controls)
+        length(address) == 0 && return
+        #is_continuous_chunk(address) || error("address not continuous in a block marked as continous.")
+        _draw!(c, [controls..., (address, c.gatestyles.g, string(cb))])
+    end
+end
+for GT in [:KronBlock, :RepeatedBlock, :CachedBlock, :Subroutine, :(YaoBlocks.AD.NoParams)]
+    @eval function draw!(c::CircuitGrid, p::$GT, address, controls)
+        barrier_style = CircuitStyles.barrier_for_chain[]
+        CircuitStyles.barrier_for_chain[] = false
+        draw!(c, YaoBlocks.Optimise.to_basictypes(p), address, controls)
+        CircuitStyles.barrier_for_chain[] = barrier_style
+    end
+end
+for (GATE, SYM) in [(:XGate, :Rx), (:YGate, :Ry), (:ZGate, :Rz)]
+    @eval get_brush_texts(c, b::RotationGate{D,T,<:$GATE}) where {D,T} = (c.gatestyles.g, "$($(SYM))($(pretty_angle(b.theta)))")
+end
+
+pretty_angle(theta) = string(theta)
+function pretty_angle(theta::AbstractFloat)
+    c = continued_fraction(theta/π, 10)
+    if c.den < 100
+        res = if c.num == 1
+            "π"
+        elseif c.num==0
+            "0"
+        elseif c.num==-1
+            "-π"
+        else
+            "$(c.num)π"
+        end
+        if c.den != 1
+            res *= "/$(c.den)"
+        end
+        res
+    else
+        "$(round(theta; digits=2))"
+    end
+end
+"""
+    continued_fraction(ϕ, n::Int) -> Rational
+
+Obtain `s` and `r` from `ϕ` that satisfies `|s//r - ϕ| ≦ 1/2r²`
+"""
+function continued_fraction(fl, n::Int)
+    if n == 1 || abs(mod(fl, 1)) < 1e-10
+        Rational(floor(Int, fl), 1)
+    else
+        floor(Int, fl) + 1//continued_fraction(1/mod(fl, 1), n-1)
+    end
+end
+
+get_brush_texts(c, ::ConstGate.SdagGate) = (c.gatestyles.g, "S'")
+get_brush_texts(c, ::ConstGate.TdagGate) = (c.gatestyles.g, "T'")
+get_brush_texts(c, ::ConstGate.PuGate) = (c.gatestyles.g, "P+")
+get_brush_texts(c, ::ConstGate.PdGate) = (c.gatestyles.g, "P-")
+get_brush_texts(c, ::ConstGate.P0Gate) = (c.gatestyles.g, "P₀")
+get_brush_texts(c, ::ConstGate.P1Gate) = (c.gatestyles.g, "P₁")
+get_brush_texts(c, b::PrimitiveBlock) = (c.gatestyles.g, string(b))
+get_brush_texts(c, b::TimeEvolution) = (c.gatestyles.g, string(b))
+get_brush_texts(c, b::ShiftGate) = (c.gatestyles.g, "ϕ($(pretty_angle(b.theta)))")
+get_brush_texts(c, b::PhaseGate) = (CircuitStyles.Phase("$(pretty_angle(b.theta))"), "")
+function get_brush_texts(c, b::T) where T<:ConstantGate
+    namestr = string(T.name.name)
+    if endswith(namestr, "Gate")
+        namestr = namestr[1:end-4]
+    end
+    # Fix!
+    (c.gatestyles.g, namestr)
+end
+
+get_cbrush_texts(c, b::PrimitiveBlock) = get_brush_texts(c, b)
+get_cbrush_texts(c, ::XGate) = (c.gatestyles.not, "")
+get_cbrush_texts(c, ::ZGate) = (c.gatestyles.c, "")
+
+# front end
+"""
+    vizcircuit(circuit; w_depth=0.85, w_line=0.75, format=:svg, filename=nothing,
+        show_ending_bar=false, starting_texts=nothing, starting_offset=-0.3,
+        ending_texts=nothing, ending_offset=0.3)
+
+Visualize a `Yao` quantum circuit.
+
+### Keyword Arguments
+* `w_depth` is the circuit column width.
+* `w_line` is the circuit row width.
+* `format` can be `:svg`, `:png` or `:pdf`.
+* `filename` can be `"*.svg"`, `"*.png"`, `"*.pdf"` or nothing (not saving to a file).
+* `starting_texts` and `ending_texts` are texts shown before and after the circuit.
+* `starting_offset` and `end_offset` are offsets (real values) for starting and ending texts.
+* `show_ending_bar` is a boolean switch to show ending bar.
+
+### Styles
+To change the gates styles like colors and lines, please modify the constants in submodule `CircuitStyles`.
+They are defined as:
+
+* CircuitStyles.unit = Ref(60)                      # number of points in a unit
+* CircuitStyles.r = Ref(0.2)                        # size of nodes
+* CircuitStyles.lw = Ref(1.0)                       # line width
+* CircuitStyles.textsize = Ref(16.0)                # text size
+* CircuitStyles.paramtextsize = Ref(10.0)           # text size (longer texts)
+* CircuitStyles.fontfamily = Ref("monospace")       # font family
+* CircuitStyles.linecolor = Ref("#000000")          # line color
+* CircuitStyles.gate_bgcolor = Ref("transparent")   # gate background color
+* CircuitStyles.textcolor = Ref("#000000")          # text color
+"""
+function vizcircuit(blk::AbstractBlock; w_depth=0.85, w_line=0.75, format=:svg, filename=nothing,
+        show_ending_bar=false, starting_texts=nothing, starting_offset=-0.3,
+        ending_texts=nothing, ending_offset=0.3, gatestyles=CircuitStyles.GateStyles())
+    img = circuit_canvas(nqudits(blk); w_depth, w_line, show_ending_bar, starting_texts, starting_offset,
+            ending_texts, ending_offset, gatestyles, format, filename) do c
+        addblock!(c, blk)
+    end
+    return img
+end
+
+addblock!(c::CircuitGrid, blk::AbstractBlock) = draw!(c, blk, collect(1:nqudits(blk)), [])
+addblock!(c::CircuitGrid, blk::Function) = addblock!(c, blk(nline(c)))
+
+function circuit_canvas(f, nline::Int; format=:svg, filename=nothing, w_depth=0.85, w_line=0.75,
+        show_ending_bar=false, starting_texts=nothing, starting_offset=-0.3, ending_texts=nothing,
+        ending_offset=0.3, gatestyles=CircuitStyles.GateStyles())
+    # the first time to estimate the canvas size
+    Luxor.Drawing(50, 50, :png)
+    c = CircuitGrid(nline; w_depth, w_line, gatestyles)
+    initialize!(c; starting_texts, starting_offset)
+    f(c)
+    finalize!(c; show_ending_bar, ending_texts, ending_offset)
+    Luxor.finish()
+    # the second time draw
+    u = CircuitStyles.unit[]
+    a, b = ceil(Int, (depth(c)+1)*w_depth*u), ceil(Int, nline*w_line*u)
+    _luxor(a, b, w_depth/2*u, -w_line/2*u; format, filename) do
+        c = CircuitGrid(nline; w_depth, w_line, gatestyles)
+        initialize!(c; starting_texts, starting_offset)
+        f(c)
+        finalize!(c; show_ending_bar, ending_texts, ending_offset)
+    end
+end
+
+function _luxor(f, Dx, Dy, offsetx, offsety; format, filename)
+    if filename === nothing
+        if format == :pdf
+            _format = tempname()*".pdf"
+        else
+            _format = format
+        end
+    else
+        _format = filename
+    end
+    Luxor.Drawing(round(Int,Dx), round(Int,Dy), _format)
+    Luxor.origin(offsetx, offsety)
+    f()
+    Luxor.finish()
+    Luxor.preview()
+end
+
+vizcircuit(; kwargs...) = c->vizcircuit(c; kwargs...)
+
+function darktheme!()
+    const CircuitStyles.linecolor[] = "#FFFFFF"
+    const CircuitStyles.textcolor[] = "#FFFFFF"
+    const BlochStyles.color[] = "#FFFFFF"
+    BlochStyles.axes_colors .= ["#FFFFFF", "#FFFFFF", "#FFFFFF"]
+end
+
+function lighttheme!()
+    const CircuitStyles.linecolor[] = "#000000"
+    const CircuitStyles.textcolor[] = "#000000"
+    const BlochStyles.color[] = "#000000"
+    BlochStyles.axes_colors .= ["#000000", "#000000", "#000000"]
+end

--- a/lib/YaoPlots/src/vizcircuit.jl
+++ b/lib/YaoPlots/src/vizcircuit.jl
@@ -1,6 +1,34 @@
+"""
+    CircuitStyles
+
+A module to define the styles of the circuit visualization.
+To change the styles, please modify the variables in this module, e.g.
+```julia
+julia> using YaoPlots
+
+julia> YaoPlots.CircuitStyles.unit[] = 40
+40
+```
+
+### Style variables
+#### Sizes
+* `unit` is the number of pixels in a unit.
+* `r` is the size of nodes.
+* `lw` is the line width.
+
+#### Texts
+* `textsize` is the text size.
+* `paramtextsize` is the text size for longer texts.
+* `fontfamily` is the font family.
+
+#### Colors
+* `linecolor` is the line color.
+* `gate_bgcolor` is the gate background color.
+* `textcolor` is the text color.
+"""
 module CircuitStyles
     using Luxor
-    const unit = Ref(60)    # number of points in a unit
+    const unit = Ref(60)    # number of pixels in a unit
     const barrier_for_chain = Ref(false)
     const r = Ref(0.2)
     const lw = Ref(1.0)
@@ -492,6 +520,11 @@ end
 
 vizcircuit(; kwargs...) = c->vizcircuit(c; kwargs...)
 
+"""
+    darktheme!()
+
+Change the default theme to dark.
+"""
 function darktheme!()
     const CircuitStyles.linecolor[] = "#FFFFFF"
     const CircuitStyles.textcolor[] = "#FFFFFF"
@@ -499,6 +532,11 @@ function darktheme!()
     BlochStyles.axes_colors .= ["#FFFFFF", "#FFFFFF", "#FFFFFF"]
 end
 
+"""
+    lighttheme!()
+
+Change the default theme to light.
+"""
 function lighttheme!()
     const CircuitStyles.linecolor[] = "#000000"
     const CircuitStyles.textcolor[] = "#000000"

--- a/lib/YaoPlots/test/bloch.jl
+++ b/lib/YaoPlots/test/bloch.jl
@@ -1,0 +1,42 @@
+using YaoPlots, Test
+using LinearAlgebra: normalize!, eigen
+using Luxor: Drawing
+using YaoBlocks
+
+@testset "spherical coo" begin
+    for i=1:10
+        x = randn(3)
+        @test collect(YaoPlots.polar_to_cartesian(YaoPlots.cartesian_to_polar(x...)...)) ≈ x
+    end
+end
+
+@testset "state to polar" begin
+    nx, ny, nz = normalize!(randn(3))
+    sigma = nx * X + ny * Y + nz * Z
+    m = Matrix(sigma)
+    E, U = eigen(m)
+    @test collect(YaoPlots.state_to_cartesian(U[:, 2])) ≈ [nx, ny, nz]
+    @test collect(YaoPlots.state_to_cartesian(U[:, 1])) ≈ -[nx, ny, nz]
+
+    reg = rand_state(1)
+    @test collect(YaoPlots.state_to_cartesian(reg)) ≈ collect(YaoPlots.state_to_cartesian(density_matrix(reg)))
+end
+
+@testset "bloch" begin
+    @test bloch_sphere("|ψ⟩"=>[2.2, 0.3im+0.3]; show_projection_lines=true,
+        show_angle_texts=true, show_line=true, show01=true) isa Drawing
+    # dark theme
+    darktheme!()
+    @test bloch_sphere("|ψ⟩"=>[2.2, 0.3im+0.3]; show_projection_lines=true,
+        show_angle_texts=true, show_line=true, show01=true) isa Drawing
+end
+
+@testset "draw reg" begin
+    @test bloch_sphere("|ψ⟩"=>rand_state(1)) isa Drawing
+end
+
+@testset "draw density matrix" begin
+    rho = density_matrix(rand_state(2), 1)
+    @test bloch_sphere("ρ"=>rho) isa Drawing
+    bloch_sphere("|ψ⟩"=>rand_state(1), "ρ"=>density_matrix(rand_state(2), 1))
+end

--- a/lib/YaoPlots/test/bloch.jl
+++ b/lib/YaoPlots/test/bloch.jl
@@ -2,6 +2,7 @@ using YaoPlots, Test
 using LinearAlgebra: normalize!, eigen
 using Luxor: Drawing
 using YaoBlocks
+using YaoArrayRegister
 
 @testset "spherical coo" begin
     for i=1:10

--- a/lib/YaoPlots/test/helperblock.jl
+++ b/lib/YaoPlots/test/helperblock.jl
@@ -1,0 +1,28 @@
+using YaoPlots, YaoBlocks, Luxor
+using Test
+
+@testset "LabelBlock" begin
+    x = put(5, (2,3)=>matblock(rand_unitary(4)))
+    cb = LabelBlock(x, "x")
+    @test mat(copy(cb)) == mat(cb)
+    @test isunitary(cb)
+    @test ishermitian(cb) == ishermitian(x)
+    @test isreflexive(cb) == isreflexive(x)
+    @test mat(cb) == mat(x)
+    reg = rand_state(5)
+    @test apply!(copy(reg), cb) ≈ apply!(copy(reg), x)
+    @test cb' isa LabelBlock && mat(cb') ≈ mat(cb)'
+    @test (cb').name == "x†" && (cb'').name == "x"
+
+    y = put(5, (3,4)=>matblock(rand_unitary(4)))
+    cc = chsubblocks(cb, y)
+    @test YaoPlots.is_continuous_chunk([1,2,3]) == true
+    @test YaoPlots.is_continuous_chunk([1,2,4]) == false
+    @test YaoPlots.is_continuous_chunk([3,2,4]) == true
+    
+    c1 = chain(5, [put(5, (2,3)=>addlabel(SWAP, "SWAP")), put(5, 2=>addlabel(I2, "id")), put(5, 2=>addlabel(X, "X")), control(5, (5,3), (2,4,1)=>put(3, (1,3)=>addlabel(SWAP, "SWAP")))])
+    c2 = chain(5, [put(5, (2,3)=>addlabel(SWAP, "SWAP")), put(5, 2=>addlabel(I2, "id")), put(5, 2=>addlabel(X, "X")), control(5, (5,3), (2,4,1)=>put(3, (1,2)=>addlabel(SWAP, "SWAP")))])
+
+    @test vizcircuit(c1) isa Drawing
+    @test vizcircuit(c2) isa Drawing
+end

--- a/lib/YaoPlots/test/helperblock.jl
+++ b/lib/YaoPlots/test/helperblock.jl
@@ -1,4 +1,5 @@
 using YaoPlots, YaoBlocks, Luxor
+using YaoArrayRegister
 using Test
 
 @testset "LabelBlock" begin

--- a/lib/YaoPlots/test/runtests.jl
+++ b/lib/YaoPlots/test/runtests.jl
@@ -1,0 +1,14 @@
+using YaoPlots
+using Test
+
+@testset "helperblock" begin
+    include("helperblock.jl")
+end
+
+@testset "vizcircuit" begin
+    include("vizcircuit.jl")
+end
+
+@testset "bloch" begin
+    include("bloch.jl")
+end

--- a/lib/YaoPlots/test/vizcircuit.jl
+++ b/lib/YaoPlots/test/vizcircuit.jl
@@ -1,7 +1,7 @@
 using YaoPlots
 using Test
 using YaoBlocks
-using YaoPlots: addblock!
+using YaoPlots: addblock!, CircuitGrid, circuit_canvas
 using YaoArrayRegister
 using Luxor
 

--- a/lib/YaoPlots/test/vizcircuit.jl
+++ b/lib/YaoPlots/test/vizcircuit.jl
@@ -2,6 +2,7 @@ using YaoPlots
 using Test
 using YaoBlocks
 using YaoPlots: addblock!
+using YaoArrayRegister
 using Luxor
 
 @testset "gate styles" begin
@@ -74,10 +75,6 @@ end
     @test plot(chain(3, put(1=>X), repeat(3, H), put(2=>Y), repeat(3, Rx(π/2)))) isa Drawing
     lighttheme!()
     @test plot(chain(3, put(1=>X), repeat(3, H), put(2=>Y), repeat(3, Rx(π/2)))) isa Drawing
-end
-
-@testset "regression" begin
-	@test vizcircuit(put(10, (8,2,3)=>EasyBuild.heisenberg(3)), starting_texts=string.(1:10), ending_texts=string.(1:10), show_ending_bar=true) isa Drawing
 end
 
 @testset "readme" begin

--- a/lib/YaoPlots/test/vizcircuit.jl
+++ b/lib/YaoPlots/test/vizcircuit.jl
@@ -1,0 +1,92 @@
+using YaoPlots
+using Test
+using YaoBlocks
+using YaoPlots: addblock!
+using Luxor
+
+@testset "gate styles" begin
+    c = YaoPlots.CircuitGrid(1)
+	@test YaoPlots.get_brush_texts(c, X)[2] == "X"
+	@test YaoPlots.get_brush_texts(c, Rx(0.5))[2] == "Rx(0.5)"
+	@test YaoPlots.get_brush_texts(c, shift(0.5))[2] == "ϕ(0.5)"
+	@test YaoPlots.get_brush_texts(c, YaoBlocks.phase(0.5))[2] == ""
+end
+
+@testset "circuit canvas" begin
+	c = CircuitGrid(5)
+	@test YaoPlots.nline(c) == 5
+	@test YaoPlots.frontier(c, 2, 3) == 0
+	@test YaoPlots.depth(c) == 0
+	circuit_canvas(5) do c
+		YaoPlots.draw!(c, put(5, 3=>X), 1:5, [])
+		@test YaoPlots.frontier(c, 1, 2) == 0
+		@test YaoPlots.frontier(c, 3, 5) == 1
+		@test YaoPlots.depth(c) == 1
+	end
+
+	gg = circuit_canvas(5) do c
+		addblock!(c, put(3=>X))
+		addblock!(c, put(3=>matblock(rand_unitary(2); tag="xxx")))
+		addblock!(c, put(3=>igate(1)))
+		addblock!(c, time_evolve(put(3,3=>igate(1)), 0.1))
+		addblock!(c, control(2, 3=>X))
+		addblock!(c, control(2, 3=>shift(0.5)))
+		addblock!(c, chain(5, control(2, 3=>X), put(1=>X)))
+		@test YaoPlots.depth(c) >= 6
+	end
+	@test gg isa Drawing
+
+	g = put(5, (3, 4)=>SWAP) |> vizcircuit(; w_line=0.8, w_depth=0.9)
+	@test g isa Drawing
+	@test vizcircuit(put(5, (3,4)=>kron(X, Y)); w_line=0.8, w_depth=0.9) isa Drawing
+
+	@test vizcircuit(control(10, (2, -3), 6=>X)) isa Drawing
+	@test vizcircuit(control(10, (2, -3), 6=>im*X)) isa Drawing
+	@test plot(put(7, (2,3)=>matblock(randn(4,4)))) isa Drawing
+    # qudit
+    @test vizcircuit(put(10, 6=>matblock(rand_unitary(3); nlevel=3, tag="3 level"))) isa Drawing
+end
+
+@testset "fix #3" begin
+	@test (control(4, 2, (1,3)=>kron(X, X)) |> vizcircuit) isa Drawing
+end
+
+@testset "pretty_angle" begin
+	@test YaoPlots.pretty_angle(π) == "π"
+	@test YaoPlots.pretty_angle(π*1.0) == "π"
+	@test YaoPlots.pretty_angle(-π*1.0) == "-π"
+	@test YaoPlots.pretty_angle(-π*0.0) == "0"
+	@test YaoPlots.pretty_angle(-π*0.5) == "-π/2"
+	@test YaoPlots.pretty_angle(1.411110) == "1.41"
+end
+
+@testset "readme" begin
+    YaoPlots.CircuitStyles.linecolor[] = "pink" 
+    YaoPlots.CircuitStyles.gate_bgcolor[] = "yellow" 
+    YaoPlots.CircuitStyles.textcolor[] = "#000080" # the navy blue color
+    YaoPlots.CircuitStyles.fontfamily[] = "JuliaMono"
+    YaoPlots.CircuitStyles.lw[] = 2.5
+    YaoPlots.CircuitStyles.textsize[] = 13
+    YaoPlots.CircuitStyles.paramtextsize[] = 8
+            
+    @test plot(chain(3, put(1=>X), repeat(3, H), put(2=>Y), repeat(3, Rx(π/2)))) isa Drawing
+    darktheme!()
+    @test plot(chain(3, put(1=>X), repeat(3, H), put(2=>Y), repeat(3, Rx(π/2)))) isa Drawing
+    lighttheme!()
+    @test plot(chain(3, put(1=>X), repeat(3, H), put(2=>Y), repeat(3, Rx(π/2)))) isa Drawing
+end
+
+@testset "regression" begin
+	@test vizcircuit(put(10, (8,2,3)=>EasyBuild.heisenberg(3)), starting_texts=string.(1:10), ending_texts=string.(1:10), show_ending_bar=true) isa Drawing
+end
+
+@testset "readme" begin
+    circuit = chain(
+        4,    
+        kron(X, H, H, H),
+        kron(1=>Y, 4=>H), 
+        put(2=>Y),
+    )
+    YaoPlots.CircuitStyles.barrier_for_chain[] = true
+    @test vizcircuit(circuit) isa Drawing
+end

--- a/lib/YaoSym/src/register.jl
+++ b/lib/YaoSym/src/register.jl
@@ -35,14 +35,14 @@ Create a ket register. See also [`@bra_str`](@ref).
 
 a symbolic quantum state can be created simply by
 
-```jldoctest; setup=:(using Yao, SymEngine)
+```jldoctest; setup=:(using Yao)
 julia> ket"110" + 2ket"111"
 |110⟩ + 2.0|111⟩
 ```
 
 qubits can be partially actived by [`focus!`](@ref)
 
-```jldoctest; setup=:(using Yao, SymEngine)
+```jldoctest; setup=:(using Yao)
 julia> ket"100" + ket"111" |> focus!(1:2)
 |100⟩ + |111⟩
 ```
@@ -62,7 +62,7 @@ Create a bra register. See also [`@ket_str`](@ref).
 Similar to `@ket_str` literal, a symbolic quantum state can be created
 by
 
-```jldoctest; setup=:(using Yao, SymEngine)
+```jldoctest; setup=:(using Yao)
 julia> bra"111" + 2bra"101"
 2.0⟨101| + ⟨111|
 

--- a/src/EasyBuild/block_extension/FSimGate.jl
+++ b/src/EasyBuild/block_extension/FSimGate.jl
@@ -51,3 +51,5 @@ function fsim_block(θ::Real, ϕ::Real)
         return cphase(2,2,1,-ϕ)*rot(SWAP,2*θ)*rot(kron(Z,Z), -θ)*put(2,1=>phase(θ/2))
     end
 end
+
+YaoPlots.get_brush_texts(c, b::FSimGate) = (c.gatestyles.g, "FSim($(pretty_angle(b.theta)), $(pretty_angle(b.phi)))")

--- a/src/EasyBuild/block_extension/shortcuts.jl
+++ b/src/EasyBuild/block_extension/shortcuts.jl
@@ -15,3 +15,8 @@ const CPhaseGate{T} = ControlBlock{<:ShiftGate{T},<:Any}
 The circuit block for initialzing a singlet state.
 """
 singlet_block() = chain(put(2, 1=>chain(X, H)), control(2, -1, 2=>X))
+
+YaoPlots.get_brush_texts(c, ::SqrtWGate) = (c.gatestyles.g, "√W")
+YaoPlots.get_brush_texts(c, ::SqrtXGate) = (c.gatestyles.g, "√X")
+YaoPlots.get_brush_texts(c, ::SqrtYGate) = (c.gatestyles.g, "√Y")
+

--- a/src/EasyBuild/easybuild.jl
+++ b/src/EasyBuild/easybuild.jl
@@ -1,6 +1,7 @@
 module EasyBuild
 using YaoBlocks, YaoBlocks.LuxurySparse, YaoBlocks.YaoAPI, YaoBlocks.YaoArrayRegister
 using YaoBlocks.LinearAlgebra
+import YaoPlots
 using YaoArrayRegister: sparse
 
 include("block_extension/blocks.jl")

--- a/src/Yao.jl
+++ b/src/Yao.jl
@@ -15,7 +15,7 @@ Extensible Framework for Quantum Algorithm Design for Humans.
 const 幺 = Yao
 
 using Reexport
-@reexport using YaoArrayRegister, YaoBlocks, YaoSym
+@reexport using YaoArrayRegister, YaoBlocks, YaoSym, YaoPlots
 export EasyBuild
 using YaoArrayRegister.BitBasis, YaoAPI
 

--- a/test/easybuild/block_extension/shortcuts.jl
+++ b/test/easybuild/block_extension/shortcuts.jl
@@ -1,6 +1,7 @@
 using Test, Yao.EasyBuild, YaoBlocks
 using YaoBlocks.Optimise: replace_block, to_basictypes, simplify
 using YaoBlocks: parse_ex
+using YaoPlots: vizcircuit, Luxor
 
 @testset "gates" begin
     @test isunitary(FSimGate(0.5, 0.6))
@@ -20,4 +21,8 @@ using YaoBlocks: parse_ex
     c  = chain(put(3,(3,1)=>fs_), chain(put(3,(1,2)=>fs_), put(3, (1,3)=>fs_), put(3, (3,2)=>fs_)))
 
     @test Matrix(c) ≈ Matrix(simplify(c_, rules=[to_basictypes]))
+end
+
+@testset "regression" begin
+	@test vizcircuit(put(10, (8,2,3)=>heisenberg(3)), starting_texts=string.(1:10), ending_texts=string.(1:10), show_ending_bar=true) isa Luxor.Drawing
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,10 +12,11 @@ using Random
     include("easybuild/easybuild.jl")
 end
 
-DocMeta.setdocmeta!(Yao, :DocTestSetup, :(using Yao, YaoAPI, YaoArrayRegister, YaoBlocks, YaoSym, BitBasis); recursive=true)
+DocMeta.setdocmeta!(Yao, :DocTestSetup, :(using Yao, YaoAPI, YaoArrayRegister, YaoBlocks, YaoPlots, YaoSym, BitBasis); recursive=true)
 
 Documenter.doctest(YaoAPI; manual=false)
 Documenter.doctest(YaoArrayRegister; manual=false)
 Documenter.doctest(YaoBlocks; manual=false)
 Documenter.doctest(YaoSym; manual=false)
+Documenter.doctest(YaoPlots; manual=false)
 Documenter.doctest(Yao; manual=false)


### PR DESCRIPTION
# List of changes
1. Include YaoPlots as a component package.
<img width="728" alt="image" src="https://github.com/QuantumBFS/Yao.jl/assets/6257240/14f4ed6a-d86c-4a91-8906-bef5bba985fe">

The using time increased from 0.68s to 0.9s on my machine.
```julia-repl
julia> @time using Yao
  0.901292 seconds (1.28 M allocations: 86.938 MiB, 5.83% gc time, 22.79% compilation time: 94% of which was recompilation)
```

2. Fixed some of the documentation.