### PR TITLE
Fix CUDA extension - Project.toml

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,12 @@ YaoPlots = "32cfe2d9-419e-45f2-8191-2267705d8dbc"
 YaoSym = "3b27209a-d3d6-11e9-3c0f-41eb92b2cb9d"
 YaoToEinsum = "9b173c7b-dc24-4dc5-a0e1-adab2f7b6ba9"
 
+[weakdeps]
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+
+[extensions]
+CuYao = "CUDA"
+
 [compat]
 BitBasis = "0.8, 0.9"
 CUDA = "4, 5"

--- a/ext/CuYao/src/CuYao.jl
+++ b/ext/CuYao/src/CuYao.jl
@@ -31,6 +31,7 @@ const Ints = NTuple{<:Any, Int}
 include("CUDApatch.jl")
 include("register.jl")
 include("instructs.jl")
+include("yao2einsum.jl")
 
 function __init__()
     CUDA.allowscalar(false)

--- a/ext/CuYao/src/yao2einsum.jl
+++ b/ext/CuYao/src/yao2einsum.jl
@@ -1,7 +1,3 @@
-module YaoToEinsumCUDAExt
-using CUDA, YaoToEinsum
-
 function CUDA.cu(tnet::TensorNetwork)
     return TensorNetwork(tnet.code, tnet.tensors .|> CuArray)
-end
 end

--- a/ext/CuYao/test/runtests.jl
+++ b/ext/CuYao/test/runtests.jl
@@ -16,3 +16,7 @@ end
 @testset "extra" begin
     include("extra.jl")
 end
+
+@testset "yao2einsum" begin
+    include("yao2einsum.jl")
+end

--- a/ext/CuYao/test/yao2einsum.jl
+++ b/ext/CuYao/test/yao2einsum.jl
@@ -1,0 +1,9 @@
+using Yao, CUDA
+using Yao.YaoToEinsum: uniformsize
+
+@testset "Yao Extensions" begin
+    n = 5
+    c = EasyBuild.qft_circuit(n)
+    optcode, xs = yao2einsum(c)
+    @test Matrix(reshape(optcode(xs...; size_info=uniformsize(optcode, 2)), 1<<n, 1<<n)) ≈ mat(c)
+end

--- a/ext/CuYao/test/yao2einsum.jl
+++ b/ext/CuYao/test/yao2einsum.jl
@@ -1,9 +1,11 @@
-using Yao, CUDA
+using Yao, CUDA, Test
 using Yao.YaoToEinsum: uniformsize
 
 @testset "Yao Extensions" begin
     n = 5
     c = EasyBuild.qft_circuit(n)
-    optcode, xs = yao2einsum(c)
-    @test Matrix(reshape(optcode(xs...; size_info=uniformsize(optcode, 2)), 1<<n, 1<<n)) ≈ mat(c)
+    net = cu(yao2einsum(c))
+    m = reshape(net.code(net.tensors...; size_info=uniformsize(net.code, 2)), 1<<n, 1<<n)
+    @test m isa CuArray
+    @test Matrix(m) ≈ mat(c)
 end

--- a/lib/YaoToEinsum/Project.toml
+++ b/lib/YaoToEinsum/Project.toml
@@ -9,7 +9,6 @@ OMEinsum = "ebe7aa44-baf0-506c-a96f-8464559b3922"
 YaoBlocks = "418bc28f-b43b-5e0b-a6e7-61bbc1a2c1df"
 
 [compat]
-CUDA = "4, 5"
 OMEinsum = "0.8"
 YaoBlocks = "0.13"
 julia = "1.9"


### PR DESCRIPTION
fix #505 

In this PR,
- I moved the CUDA extension of YaoToEinsum to CuYao.
- Restored the `[weakdeps]` and `[extensions]` sections that removed in a previous commit.