### PR TITLE
Annotate a single line (for quantum error correction)

### DIFF
--- a/docs/src/man/registers.md
+++ b/docs/src/man/registers.md
@@ -140,7 +140,7 @@ We also have some "cheating" version [`measure`](@ref) that does not collapse st
 ```@repl register
 measure!(reg0, 1)  # measure the qubit, the state collapses
 measure!(reg0)  # measure all qubits
-measure(reg0, 3)  # measure the qubit 3 times, the state does not collapse (hacky)
+measure(reg0, 3)  # measure the qubit at location 3, the state does not collapse (hacky)
 reorder!(reg0, 7:-1:1)  # reorder the qubits
 measure!(reg0)
 invorder!(reg0)  # reverse the order of qubits

--- a/lib/YaoBlocks/test/primitive/time_evolution.jl
+++ b/lib/YaoBlocks/test/primitive/time_evolution.jl
@@ -108,12 +108,17 @@ end
         mpb = mat(pb)
         allpass = true
         for i=basis(pb), j=basis(pb)
+            allpass &= isapprox(pb[i, j], mpb[Int(i)+1, Int(j)+1]; atol=1e-6)
             allpass &= isapprox(pb[i, j], mpb[Int(i)+1, Int(j)+1]; atol=1e-6, rtol=1e-6)
         end
         @test allpass
 
         allpass = true
         for j=basis(pb)
+            allpass &= isapprox(vec(pb[:, j]), mpb[:, Int(j)+1]; atol=1e-6)
+            allpass &= isapprox(vec(pb[j,:]), mpb[Int(j)+1,:]; atol=1e-6)
+            allpass &= isapprox(vec(pb[:, EntryTable([j], [1.0+0im])]), mpb[:, Int(j)+1]; atol=1e-6)
+            allpass &= isapprox(vec(pb[EntryTable([j], [1.0+0im]),:]), mpb[Int(j)+1,:]; atol=1e-6)
             allpass &= isapprox(vec(pb[:, j]), mpb[:, Int(j)+1]; atol=1e-6, rtol=1e-6)
             allpass &= isapprox(vec(pb[j,:]), mpb[Int(j)+1,:]; atol=1e-6, rtol=1e-6)
             allpass &= isapprox(vec(pb[:, EntryTable([j], [1.0+0im])]), mpb[:, Int(j)+1]; atol=1e-6, rtol=1e-6)

--- a/lib/YaoPlots/Project.toml
+++ b/lib/YaoPlots/Project.toml
@@ -5,14 +5,12 @@ version = "0.9.2"
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Luxor = "ae8d54c2-7ccd-5906-9d76-62fc9837b5bc"
-Thebes = "8b424ff8-82f5-59a4-86a6-de3761897198"
 YaoArrayRegister = "e600142f-9330-5003-8abb-0ebd767abc51"
 YaoBlocks = "418bc28f-b43b-5e0b-a6e7-61bbc1a2c1df"
 
 [compat]
 LinearAlgebra = "1"
-Luxor = "3"
-Thebes = "1"
+Luxor = "4"
 YaoArrayRegister = "0.9"
 YaoBlocks = "0.13"
 julia = "1"

--- a/lib/YaoPlots/README.md
+++ b/lib/YaoPlots/README.md
@@ -23,7 +23,7 @@ using YaoPlots, Yao
 reg = zero_state(1) |> Rx(π/8) |> Rx(π/8)
 rho = density_matrix(ghz_state(2), 1)
 
-bloch_sphere("|ψ⟩"=>reg, "ρ"=>rho; show_projection_lines=true)
+bloch_sphere("|ψ>"=>reg, "ρ"=>rho; show_projection_lines=true)
 ```
 
 Similarly, you will see

--- a/lib/YaoPlots/src/3d.jl
+++ b/lib/YaoPlots/src/3d.jl
@@ -1,0 +1,100 @@
+# The following code is copied from Thebes.jl, which is a package for 3D plotting in Julia.
+# Since Thebes.jl is not updated for a while, we need to update the code to make it work with the latest version of Luxor.jl.
+
+module Thebes
+using Luxor
+struct Point3D
+    x::Float64
+    y::Float64
+    z::Float64
+end
+
+mutable struct Projection
+    U::Point3D     #
+    V::Point3D     #
+    W::Point3D     #
+    ue::Float64    #
+    ve::Float64    #
+    we::Float64    #
+    eyepoint::Point3D
+    centerpoint::Point3D
+    uppoint::Point3D
+    perspective::Float64 #
+end
+
+function newprojection(ipos::Point3D, center::Point3D, up::Point3D, perspective=0.0)
+    if iszero(ipos.x)
+        ipos = Point3D(10e-9, ipos.y, ipos.z)
+    end  
+    if iszero(ipos.y)
+        ipos = Point3D(ipos.x, 10e-9, ipos.z)
+    end  
+    if iszero(ipos.z)
+        ipos = Point3D(ipos.x, ipos.y, 10e-9)
+    end  
+
+    # w is the line of sight
+    W = Point3D(center.x - ipos.x, center.y - ipos.y, center.z - ipos.z)
+    r = (W.x * W.x) + (W.y * W.y) + (W.z * W.z)
+    if r < eps()
+        @info("eye position and center are the same")
+        
+        W = Point3D(0.0, 0.0, 0.0)
+    else
+        # distancealise w to unit length
+        rinv = 1 / sqrt(r)
+        W = Point3D(W.x * rinv, W.y * rinv, W.z * rinv)
+    end
+    we = W.x * ipos.x + W.y * ipos.y + W.z * ipos.z # project e on to w
+    U = Point3D(W.y * (up.z - ipos.z) - W.z * (up.y - ipos.y),      # u is at right angles to t - e
+        W.z * (up.x - ipos.x) - W.x * (up.z - ipos.z),      # and w ., its' the pictures x axis
+        W.x * (up.y - ipos.y) - W.y * (up.x - ipos.x))
+    r = (U.x * U.x) + (U.y * U.y) + (U.z * U.z)
+
+    if r < eps()
+        @info("struggling to make a valid projection with these parameters")
+        U = Point3D(0.0, 0.0, 0.0)
+    else
+        rinv = 1 / sqrt(r) # distancealise u
+        U = Point3D(U.x * rinv, U.y * rinv, U.z * rinv)
+    end
+
+    ue = U.x * ipos.x + U.y * ipos.y + U.z * ipos.z # project e onto u
+
+    V = Point3D(U.y * W.z - U.z * W.y, # v is at right angles to u and w
+        U.z * W.x - U.x * W.z, # it's the world's y axis
+        U.x * W.y - U.y * W.x)
+
+    ve = V.x * ipos.x + V.y * ipos.y + V.z * ipos.z # project e onto v
+
+    Projection(U, V, W, ue, ve, we, ipos, center, up, perspective)
+end
+
+function project(proj::Projection, P::Point3D)
+    # use default value for perspectiveness if not specified
+    r = proj.W.x * P.x + proj.W.y * P.y + proj.W.z * P.z - proj.we
+    if r < eps()
+        # "point $P is behind eye"
+        result = nothing
+    else
+        if proj.perspective == 0.0
+            depth = 1
+        else
+            depth = proj.perspective * (1 / r)
+        end
+        uq = depth * (proj.U.x * P.x + proj.U.y * P.y + proj.U.z * P.z - proj.ue)
+        vq = depth * (proj.V.x * P.x + proj.V.y * P.y + proj.V.z * P.z - proj.ve)
+        result = Point(uq, -vq) # because Y is down the page in Luxor (?!)
+    end
+    return result
+end
+
+function eyepoint(pt::Point3D)
+    return newprojection(pt, Point3D(0, 0, 0), Point3D(0, 0, 1))
+end
+
+function Luxor.distance(p1::Point3D, p2::Point3D)
+    sqrt((p2.x - p1.x)^2 + (p2.y - p1.y)^2 + (p2.z - p1.z)^2)
+end
+
+end

--- a/lib/YaoPlots/src/YaoPlots.jl
+++ b/lib/YaoPlots/src/YaoPlots.jl
@@ -4,9 +4,7 @@ using YaoBlocks
 using YaoBlocks.DocStringExtensions
 using YaoArrayRegister
 import Luxor
-import Thebes
 using Luxor: @layer, Point
-using Thebes: Point3D, project
 using LinearAlgebra: tr
 using YaoBlocks
 
@@ -21,6 +19,8 @@ plot(blk::AbstractBlock; kwargs...) = vizcircuit(blk; kwargs...)
 
 include("helperblock.jl")
 include("vizcircuit.jl")
+include("3d.jl")
+using .Thebes: Point3D, project
 include("bloch.jl")
 
 end

--- a/lib/YaoPlots/src/YaoPlots.jl
+++ b/lib/YaoPlots/src/YaoPlots.jl
@@ -8,10 +8,12 @@ import Thebes
 using Luxor: @layer, Point
 using Thebes: Point3D, project
 using LinearAlgebra: tr
+using YaoBlocks
 
 export CircuitStyles, vizcircuit, darktheme!, lighttheme!
 export bloch_sphere, BlochStyles
 export plot
+export LabelBlock, addlabel, LineAnnotation, line_annotation
 
 """An alias of `vizcircuit`"""
 plot(;kwargs...) = x->plot(x;kwargs...)

--- a/lib/YaoPlots/src/helperblock.jl
+++ b/lib/YaoPlots/src/helperblock.jl
@@ -1,6 +1,3 @@
-using YaoBlocks
-export LabelBlock
-
 """
     LabelBlock{BT,D} <: TagBlock{BT,D}
 
@@ -31,7 +28,6 @@ Base.adjoint(x::LabelBlock) = LabelBlock(adjoint(content(x)), endswith(x.name, "
 Base.copy(x::LabelBlock) = LabelBlock(copy(content(x)), x.name, x.color)
 YaoBlocks.Optimise.to_basictypes(block::LabelBlock) = block
 
-export addlabel
 addlabel(b::AbstractBlock; name=string(b), color="transparent") = LabelBlock(b, name, color)
 
 # to fix issue 
@@ -49,3 +45,17 @@ function YaoBlocks.print_tree(
 )
    print(io, node.name)
 end
+
+"""
+    LineAnnotation{D} <: TrivialGate{D}
+"""
+struct LineAnnotation{D} <: TrivialGate{D}
+    name::String
+    color::String
+end
+line_annotation(name::String; color="black", nlevel=2) = LineAnnotation{nlevel}(name, color)
+
+Base.copy(x::LineAnnotation) = LineAnnotation(x.name, x.color)
+YaoBlocks.Optimise.to_basictypes(block::LineAnnotation) = block
+YaoBlocks.nqudits(::LineAnnotation) = 1
+YaoBlocks.print_block(io::IO, blk::LineAnnotation) = YaoBlocks.printstyled(io, blk.name; color=Symbol(blk.color))

--- a/lib/YaoPlots/src/vizcircuit.jl
+++ b/lib/YaoPlots/src/vizcircuit.jl
@@ -313,6 +313,7 @@ end
 
 # composite
 function draw!(c::CircuitGrid, p::ChainBlock, address, controls)
+    CircuitStyles.barrier_for_chain[] && set_barrier!(c, Int[address..., controls...])
     for block in subblocks(p)
         draw!(c, block, address, controls)
     end

--- a/lib/YaoPlots/src/vizcircuit.jl
+++ b/lib/YaoPlots/src/vizcircuit.jl
@@ -315,8 +315,8 @@ end
 function draw!(c::CircuitGrid, p::ChainBlock, address, controls)
     for block in subblocks(p)
         draw!(c, block, address, controls)
-        CircuitStyles.barrier_for_chain[] && set_barrier!(c, Int[address..., controls...])
     end
+    CircuitStyles.barrier_for_chain[] && set_barrier!(c, Int[address..., controls...])
 end
 
 function set_barrier!(c::CircuitGrid, locs::AbstractVector{Int})

--- a/lib/YaoPlots/src/vizcircuit.jl
+++ b/lib/YaoPlots/src/vizcircuit.jl
@@ -34,7 +34,7 @@ module CircuitStyles
     const lw = Ref(1.0)
     const textsize = Ref(16.0)
     const paramtextsize = Ref(10.0)
-    const fontfamily = Ref("monospace")
+    const fontfamily = Ref("JuliaMono")
     #const fontfamily = Ref("Dejavu Sans")
     const linecolor = Ref("#000000")
     const gate_bgcolor = Ref("transparent")
@@ -439,7 +439,7 @@ get_brush_texts(c, ::ConstGate.P0Gate) = (c.gatestyles.g, "P₀")
 get_brush_texts(c, ::ConstGate.P1Gate) = (c.gatestyles.g, "P₁")
 get_brush_texts(c, b::PrimitiveBlock) = (c.gatestyles.g, string(b))
 get_brush_texts(c, b::TimeEvolution) = (c.gatestyles.g, string(b))
-get_brush_texts(c, b::ShiftGate) = (c.gatestyles.g, "ϕ($(pretty_angle(b.theta)))")
+get_brush_texts(c, b::ShiftGate) = (c.gatestyles.g, "φ($(pretty_angle(b.theta)))")
 get_brush_texts(c, b::PhaseGate) = (CircuitStyles.Phase("$(pretty_angle(b.theta))"), "")
 function get_brush_texts(c, b::T) where T<:ConstantGate
     namestr = string(T.name.name)
@@ -480,7 +480,7 @@ They are defined as:
 * CircuitStyles.lw = Ref(1.0)                       # line width
 * CircuitStyles.textsize = Ref(16.0)                # text size
 * CircuitStyles.paramtextsize = Ref(10.0)           # text size (longer texts)
-* CircuitStyles.fontfamily = Ref("monospace")       # font family
+* CircuitStyles.fontfamily = Ref("JuliaMono")       # font family
 * CircuitStyles.linecolor = Ref("#000000")          # line color
 * CircuitStyles.gate_bgcolor = Ref("transparent")   # gate background color
 * CircuitStyles.textcolor = Ref("#000000")          # text color

--- a/lib/YaoPlots/src/vizcircuit.jl
+++ b/lib/YaoPlots/src/vizcircuit.jl
@@ -374,6 +374,18 @@ function draw!(c::CircuitGrid, cb::LabelBlock, address, controls)
     CircuitStyles.gate_bgcolor[] = temp
 end
 
+function draw!(c::CircuitGrid, cb::LineAnnotation, address, controls)
+    @assert length(address) == 1 && isempty(controls) "LineAnnotation should be a single line, without control."
+    CircuitStyles.textcolor[], temp = cb.color, CircuitStyles.textcolor[]
+    _annotate!(c, address[1], cb.name)
+    CircuitStyles.textcolor[] = temp
+end
+function _annotate!(c::CircuitGrid, loc::Integer, name::AbstractString)
+    wspace, fontsize = text_width_and_size(name)
+    i = frontier(c, loc) + 0.1
+    CircuitStyles.render(CircuitStyles.Text(fontsize), (c[i, loc-0.2], name, wspace, fontsize))
+end
+
 # [:KronBlock, :RepeatedBlock, :CachedBlock, :Subroutine, :(YaoBlocks.AD.NoParams)]
 function draw!(c::CircuitGrid, p::CompositeBlock, address, controls)
     barrier_style = CircuitStyles.barrier_for_chain[]

--- a/lib/YaoPlots/test/helperblock.jl
+++ b/lib/YaoPlots/test/helperblock.jl
@@ -27,3 +27,10 @@ using Test
     @test vizcircuit(c1) isa Drawing
     @test vizcircuit(c2) isa Drawing
 end
+
+@testset "annotate line" begin
+    ann = line_annotation("test"; color="red")
+    @test ann isa LineAnnotation
+    c = chain(put(5, 2=>X), put(5, 2=>ann),  put(5, 3=>Y))
+    @test vizcircuit(c) isa Drawing
+end

--- a/lib/YaoPlots/test/vizcircuit.jl
+++ b/lib/YaoPlots/test/vizcircuit.jl
@@ -9,7 +9,7 @@ using Luxor
     c = YaoPlots.CircuitGrid(1)
 	@test YaoPlots.get_brush_texts(c, X)[2] == "X"
 	@test YaoPlots.get_brush_texts(c, Rx(0.5))[2] == "Rx(0.5)"
-	@test YaoPlots.get_brush_texts(c, shift(0.5))[2] == "ϕ(0.5)"
+	@test YaoPlots.get_brush_texts(c, shift(0.5))[2] == "φ(0.5)"
 	@test YaoPlots.get_brush_texts(c, YaoBlocks.phase(0.5))[2] == ""
 end
 


### PR DESCRIPTION
<img width="101" alt="image" src="https://github.com/QuantumBFS/Yao.jl/assets/6257240/43f1fa0c-f00f-470d-9a1e-90c32d4f2382">

```julia
julia> c = chain(put(5, 2=>X), put(5, 2=>line_annotation("!!!"; color="green")),  put(5, 3=>Y), control(5, 2, 3=>X))
nqubits: 5
chain
├─ put on (2)
│  └─ X
├─ put on (2)
│  └─ !!!
├─ put on (3)
│  └─ Y
└─ control(2)
   └─ (3,) X


julia> vizcircuit(c)
```