### PR TITLE
Fix collapseto! normalization and add test for mixed states

### DIFF
--- a/lib/YaoArrayRegister/src/density_matrix.jl
+++ b/lib/YaoArrayRegister/src/density_matrix.jl
@@ -226,11 +226,10 @@ function YaoAPI.collapseto!(rho::DensityMatrix, locsval::Pair)
     st = rho.state[ic, ic]
     
     trace_norm = tr(st)  
-    if real(trace_norm) > 1e-10
-        st ./= trace_norm  
-    else
+    if real(trace_norm) <= 1e-10
         @warn "Collapse resulted in a near-zero probability state. Normalization may be inaccurate."
     end
+    st ./= trace_norm  
     fill!(rho.state, 0)
     rho.state[ic, ic] .= st
     return rho

--- a/lib/YaoArrayRegister/src/density_matrix.jl
+++ b/lib/YaoArrayRegister/src/density_matrix.jl
@@ -223,7 +223,14 @@ end
 function YaoAPI.collapseto!(rho::DensityMatrix, locsval::Pair)
     locs = locsval.first isa AllLocs ? (1:nqudits(rho)) : locsval.first
     ic = itercontrol(nqudits(rho), collect(locs), locsval.second) .+ 1
-    st = normalize!(rho.state[ic, ic])
+    st = rho.state[ic, ic]
+    
+    trace_norm = tr(st)  
+    if real(trace_norm) > 1e-10
+        st ./= trace_norm  
+    else
+        @warn "Collapse resulted in a near-zero probability state. Normalization may be inaccurate."
+    end
     fill!(rho.state, 0)
     rho.state[ic, ic] .= st
     return rho

--- a/lib/YaoArrayRegister/test/density_matrix.jl
+++ b/lib/YaoArrayRegister/test/density_matrix.jl
@@ -228,6 +228,13 @@ end
     @test isnormalized(r)
 end
 
+@testset "collapseto! with mixed states" begin
+    rho = rand_density_matrix(8)
+    collapseto!(rho, (5:8) => zeros(Int,4))  
+    @test tr(rho.state) ≈ 1
+end
+
+
 @testset "measure on subset of qubits" begin
     r1 = density_matrix(arrayreg(bit"110"))
     r2 = density_matrix(arrayreg(bit"101"))


### PR DESCRIPTION
This PR fixes collapseto! to normalize density matrices properly, based on #534. Adds a warning when collapse results in a near-zero probability state. A test is added to ensure normalization remains valid in these cases.