### PR TITLE
Fixed typos in docs examples

### DIFF
--- a/docs/src/examples/2.qft-phase-estimation/main.jl
+++ b/docs/src/examples/2.qft-phase-estimation/main.jl
@@ -26,7 +26,7 @@ using Yao
 
 A(i, j) = control(i, j=>shift(2π/(1<<(i-j+1))))
 
-# Once you construct the blockl you can inspect its matrix using `mat`
+# Once you construct the block you can inspect its matrix using `mat`
 # function. Let's construct the circuit in dash box A, and see the matrix of
 # ``R_4`` gate.
 
@@ -154,7 +154,7 @@ PE(n, m, U) =
 # back, after the context. This is equivalent to manually `focus!`
 # then `relax!`
 
-# fullly activated
+# fully activated
 
 r = rand_state(5)
 

--- a/docs/src/examples/3.grover-search/main.jl
+++ b/docs/src/examples/3.grover-search/main.jl
@@ -50,7 +50,7 @@ for i = 1:num_grover_step(oracle, gen)
 end
 
 # ## Rejection Sampling
-# In practise, it is often not possible to determine the number of iterations before actual running.
+# In practice, it is often not possible to determine the number of iterations before actual running.
 # we can use rejection sampling technique to avoid estimating the number of grover steps.
 
 using Random; Random.seed!(2)  #src
@@ -73,8 +73,8 @@ end
 
 # After running the grover search, we have a checker program that flips the ancilla qubit
 # if the output is the desired value, we assume the checker program can be implemented in polynomial time.
-# to gaurante the output is correct.
-# We contruct a checker "program", if the result is correct, flip the ancilla qubit
+# to guarantee the output is correct.
+# We construct a checker "program", if the result is correct, flip the ancilla qubit
 ctrl = -collect(1:num_bit); ctrl[[3,6,7]] *= -1
 checker = control(num_bit+1,ctrl, num_bit+1=>X)
 

--- a/docs/src/examples/4.shor-algorithm/main.jl
+++ b/docs/src/examples/4.shor-algorithm/main.jl
@@ -1,7 +1,7 @@
 # # [Shor's Algorithm](@id Shor)
 
 # ## References
-# * [Neilsen](https://aapt.scitation.org/doi/abs/10.1119/1.1463744?journalCode=ajp)
+# * [Nielsen](https://aapt.scitation.org/doi/abs/10.1119/1.1463744?journalCode=ajp)
 # * [An Insightful Blog](https://algassert.com/post/1718)
 
 # The main program of a Shor's algorithm can be summarized in several lines of code.
@@ -205,12 +205,12 @@ function shor(L::Int, ver=Val(:quantum); maxtry=100)
 end
 
 # Except some shortcuts, in each try, the main program can be summarized in several steps
-# 1. randomly pick a number that prime to the input numebr `L`, i.e. `gcd(x, L) = 1`.
+# 1. randomly pick a number that prime to the input number `L`, i.e. `gcd(x, L) = 1`.
 # The complexity of this algorithm is polynomial.
 # 2. get the order `x`, i.e. finding a number `r` that satisfies `mod(x^r, L) = 1`.
 # If `r` is even and `x^(r÷2)` is non-trivial, go on, otherwise start another try.
 # Here, trivial means equal to `L-1 (mod L)`.
-# 3. According to Theorem 5.2 in Neilsen book,
+# 3. According to Theorem 5.2 in Nielsen book,
 # one of `gcd(x^(r÷2)-1, L)` and `gcd(x^(r÷2)+1, L)` must be a non-trivial (`!=1`) factor of `L`.
 # Notice `powermod(x, r÷2, L)` must be `-1` rather than `1`,
 # otherwise the order should be `r/2` according to definition.
@@ -278,7 +278,7 @@ end
 # 2. `KMod` that computes a classical function `mod(a^k*x, L)`.
 # `k` is the integer stored in first `K` (or `ncbit`) qubits and the rest `N-K` qubits stores `a`.
 # Notice it is not a basic gate, it should have been compiled to multiple gates, which is not implemented in `Yao` for the moment.
-# To learn more about implementing arithmatics on a quantum circuit, please read [this paper](https://arxiv.org/abs/1805.12445).
+# To learn more about implementing arithmetics on a quantum circuit, please read [this paper](https://arxiv.org/abs/1805.12445).
 # 3. Inverse quantum fourier transformation.
 
 # ## Run

--- a/docs/src/examples/6.quantum-circuit-born-machine/main.jl
+++ b/docs/src/examples/6.quantum-circuit-born-machine/main.jl
@@ -11,7 +11,7 @@ using Yao, LinearAlgebra, Plots
 # ## Training Target
 
 # In this tutorial, we will ask the variational circuit to learn the most basic
-# distribution: a guassian distribution. It is defined as follows:
+# distribution: a Gaussian distribution. It is defined as follows:
 
 # ```math
 # f(x \left| \mu, \sigma^2\right) = \frac{1}{\sqrt{2\pi\sigma^2}} e^{-\frac{(x-\mu)^2}{2\sigma^2}}
@@ -33,7 +33,7 @@ Plots.plot(pg)
 
 # A quantum circuit born machine looks like the following:
 
-# ![differentiable ciruit](assets/differentiable.png)
+# ![differentiable circuit](assets/differentiable.png)
 
 # It is composited by two different layers: **rotation layer** and **entangler layer**.
 
@@ -53,7 +53,7 @@ Plots.plot(pg)
 # use ``Rz(\theta)\cdot Rx(\theta)``
 
 # In **幺**, every Hilbert operator is a **block** type, this
-# ncludes all **quantum gates** and **quantum oracles**.
+# includes all **quantum gates** and **quantum oracles**.
 # In general, operators appears in a quantum circuit
 # can be divided into **Composite Blocks** and **Primitive Blocks**.
 
@@ -84,8 +84,8 @@ layer(nbit::Int, x::Symbol) = layer(nbit, Val(x))
 layer(nbit::Int, ::Val{:first}) = chain(nbit, put(i=>chain(Rx(0), Rz(0))) for i = 1:nbit);
 
 # We do not need to feed the first `n` parameter into `put` here.
-# All factory methods can be **lazy** evaluate **the first arguements**, which is the number of qubits.
-# It will return a lambda function that requires a single interger input.
+# All factory methods can be **lazy** evaluate **the first arguments**, which is the number of qubits.
+# It will return a lambda function that requires a single integer input.
 # The instance of desired block will only be constructed until all the information is filled.
 # When you filled all the information in somewhere of the declaration, 幺 will be able to infer the others.
 # We will now define the rest of rotation layers


### PR DESCRIPTION
Corrected typos in the example files within the `docs/src/examples` folder. No changes were made to the actual code; only spelling issues in the documentation were addressed.
