### PR TITLE
Support more error types

### DIFF
--- a/docs/src/examples/9.noisy-simulation/main.jl
+++ b/docs/src/examples/9.noisy-simulation/main.jl
@@ -1,8 +1,9 @@
+# # Noisy Simulation
+
 using Yao
 using YaoBlocks.Optimise: replace_block
 using CairoMakie
 
-# # Noisy Simulation
 # To start, we create a simple circuit that we want to simulate, the one generating the 4-qubit GHZ state $|\psi\rangle = \frac{1}{\sqrt{2}}(|0000\rangle + |1111\rangle)$.
 # The code is as follows:
 n_qubits = 4
@@ -40,3 +41,130 @@ samples = measure(rho, nshots=1000);
 
 # Visualize the results
 hist(map(x -> x.buf, samples))
+
+# # Error Types and Quantum Channels
+# 
+# Yao provides various types of quantum errors and their corresponding quantum channel representations. 
+# Let's explore the different error types available:
+
+# ## 1. Bit Flip Error
+# A bit flip error with probability p applies X gate with probability p
+bit_flip = BitFlipError(0.1)
+bit_flip_channel = quantum_channel(bit_flip)
+println("Bit Flip Error Channel: ", bit_flip_channel)
+
+# ## 2. Phase Flip Error  
+# A phase flip error with probability p applies Z gate with probability p
+phase_flip = PhaseFlipError(0.1)
+phase_flip_channel = quantum_channel(phase_flip)
+println("Phase Flip Error Channel: ", phase_flip_channel)
+
+# ## 3. Depolarizing Error
+# A depolarizing error with probability p applies X, Y, or Z gate with equal probability p/3
+depolarizing = DepolarizingError(1, 0.1)
+depolarizing_channel = quantum_channel(depolarizing)
+println("Depolarizing Error Channel: ", depolarizing_channel)
+
+# ## 4. Pauli Error
+# A Pauli error with probabilities px, py, pz for X, Y, Z gates respectively
+pauli_error = PauliError(0.05, 0.03, 0.02)
+pauli_channel = quantum_channel(pauli_error)
+println("Pauli Error Channel: ", pauli_channel)
+
+# ## 5. Reset Error
+# A reset error that resets qubits to |0⟩ or |1⟩ with given probabilities
+reset_error = ResetError(0.1, 0.05)  # p0, p1
+reset_channel = quantum_channel(reset_error)
+println("Reset Error Channel: ", reset_channel)
+
+# ## 6. Thermal Relaxation Error
+# Models decoherence with T1 and T2 times
+thermal_relaxation = ThermalRelaxationError(100.0, 200.0, 1.0, 0.0)
+thermal_channel = quantum_channel(thermal_relaxation)
+println("Thermal Relaxation Error Channel: ", thermal_relaxation)
+
+# ## 7. Amplitude Damping Error
+# Models energy loss to environment
+amplitude_damping = AmplitudeDampingError(0.1)
+amplitude_channel = quantum_channel(amplitude_damping)
+println("Amplitude Damping Error Channel: ", amplitude_damping)
+
+# ## 8. Phase Damping Error
+# Models pure dephasing
+phase_damping = PhaseDampingError(0.1)
+phase_channel = quantum_channel(phase_damping)
+println("Phase Damping Error Channel: ", phase_damping)
+
+# ## 9. Phase-Amplitude Damping Error
+# Combines both amplitude and phase damping
+phase_amplitude_damping = PhaseAmplitudeDampingError(0.1, 0.05, 0.0)
+phase_amplitude_channel = quantum_channel(phase_amplitude_damping)
+println("Phase-Amplitude Damping Error Channel: ", phase_amplitude_damping)
+
+# ## 10. Coherent Error
+# A deterministic error represented by a quantum gate
+coherent_error = CoherentError(X)
+coherent_channel = quantum_channel(coherent_error)
+println("Coherent Error Channel: ", coherent_error)
+
+# # Channel Representations
+# 
+# Each error type can be converted to different channel representations:
+
+# ## Kraus Channel Representation
+# Represents the channel as a set of Kraus operators
+bit_flip_kraus = KrausChannel(bit_flip)
+println("Bit Flip Kraus Operators:")
+for (i, op) in enumerate(bit_flip_kraus.operators)
+    println("K$i = ", mat(op))
+end
+
+# ## Mixed Unitary Channel Representation  
+# Represents the channel as a convex combination of unitary operators
+bit_flip_mixed = MixedUnitaryChannel(bit_flip)
+println("Bit Flip Mixed Unitary Channel:")
+for (i, (prob, gate)) in enumerate(zip(bit_flip_mixed.probs, bit_flip_mixed.operators))
+    println("p$i = $prob, U$i = ", mat(gate))
+end
+
+# ## Superoperator Representation
+# Represents the channel as a superoperator matrix
+bit_flip_superop = SuperOp(bit_flip)
+println("Bit Flip Superoperator Matrix:")
+println(bit_flip_superop.superop)
+
+# # Example: Comparing Different Error Types
+# 
+# Let's compare how different error types affect a simple circuit:
+
+# Create a simple test circuit
+test_circ = chain(2, put(1=>H), control(2, 1=>X))
+
+# Test different error types
+error_types = [
+    ("Bit Flip", BitFlipError(0.1)),
+    ("Phase Flip", PhaseFlipError(0.1)), 
+    ("Depolarizing", DepolarizingError(1, 0.1)),
+    ("Amplitude Damping", AmplitudeDampingError(0.1)),
+    ("Phase Damping", PhaseDampingError(0.1))
+]
+
+println("\nComparing different error types on a 2-qubit circuit:")
+for (name, error) in error_types
+    # Add error after each gate
+    noisy_circ = replace_block(test_circ) do block
+        if block isa PutBlock && length(block.locs) == 1
+            chain(block, put(nqubits(block), block.locs => quantum_channel(error)))
+        elseif block isa ControlBlock && length(block.ctrl_locs) == 1 && length(block.locs) == 1
+            chain(block, put(nqubits(block), (block.ctrl_locs..., block.locs...) => 
+                kron(quantum_channel(error), quantum_channel(error))))
+        else
+            block
+        end
+    end
+    
+    # Simulate
+    rho = noisy_simulation(zero_state(2), noisy_circ)
+    fid = fidelity(rho, apply(density_matrix(zero_state(2)), test_circ))
+    println("$name Error: Fidelity = $(round(fid, digits=3))")
+end

--- a/lib/YaoBlocks/src/channel/channel.jl
+++ b/lib/YaoBlocks/src/channel/channel.jl
@@ -1,5 +1,10 @@
+# error types
 export AbstractErrorType, BitFlipError, PhaseFlipError, DepolarizingError, PauliError, ResetError,
-    KrausChannel, MixedUnitaryChannel, DepolarizingChannel, quantum_channel, SuperOp,
+    ThermalRelaxationError, PhaseAmplitudeDampingError, PhaseDampingError, AmplitudeDampingError,
+    CoherentError
+
+# channels
+export KrausChannel, MixedUnitaryChannel, DepolarizingChannel, quantum_channel, SuperOp,
     add_noise, noisy_simulation
 
 """

--- a/lib/YaoBlocks/src/channel/errortypes.jl
+++ b/lib/YaoBlocks/src/channel/errortypes.jl
@@ -1,13 +1,39 @@
 abstract type AbstractErrorType end
 
 """
+    CoherentError{BT<:AbstractBlock} <: AbstractErrorType
+    CoherentError(block::BT)
+
+Coherent unitary error channel with error gate `block`.
+
+# Fields
+- `block::BT`: the error gate
+"""
+struct CoherentError{BT<:AbstractBlock} <: AbstractErrorType
+    block::BT
+    function CoherentError(block::BT) where BT<:AbstractBlock
+        isunitary(block) || throw(ArgumentError("block must be unitary, got $(block)"))
+        new{BT}(block)
+    end
+end
+quantum_channel(err::CoherentError) = MixedUnitaryChannel(err)
+MixedUnitaryChannel(err::CoherentError) = MixedUnitaryChannel([err.block], [1.0])
+
+"""
     BitFlipError(p)
 
 Bit flip error channel with error probability `p`.
 It is equivalent to the [`PauliError`](@ref) channel with `px = py = 0` and `pz = p`.
+
+# Fields
+- `p::RT`: the error probability, must be non-negative and less than or equal to 1
 """
 struct BitFlipError{RT<:Real} <: AbstractErrorType
     p::RT
+    function BitFlipError(p::RT) where RT<:Real
+        0 ≤ p ≤ 1 || throw(ArgumentError("p must be in [0, 1], got $p"))
+        new{RT}(p)
+    end
 end
 MixedUnitaryChannel(p::BitFlipError) = MixedUnitaryChannel([I2, X], [1-p.p, p.p])
 
@@ -16,21 +42,42 @@ MixedUnitaryChannel(p::BitFlipError) = MixedUnitaryChannel([I2, X], [1-p.p, p.p]
 
 Phase flip error channel with error probability `p`.
 It is equivalent to the [`PauliError`](@ref) channel with `px = py = p` and `pz = 0`.
+
+# Fields
+- `p::RT`: the error probability, must be non-negative and less than or equal to 1
 """
 struct PhaseFlipError{RT<:Real} <: AbstractErrorType
     p::RT
+    function PhaseFlipError(p::RT) where RT<:Real
+        0 ≤ p ≤ 1 || throw(ArgumentError("p must be in [0, 1], got $p"))
+        new{RT}(p)
+    end
 end
 MixedUnitaryChannel(p::PhaseFlipError) = MixedUnitaryChannel([I2, Z], [1-p.p, p.p])
 
 """
     DepolarizingError(p)
 
-Depolarizing error channel with error probability `p`.
-It is equivalent to the [`PauliError`](@ref) channel with `px = py = pz = p/4`.
+Depolarizing error channel with error probability `p` for `n` qubits. It is defined as:
+```math
+E(ρ) = (1 - p) ρ + p \\tr(ρ) \\frac{I}{2^n}
+```
+where `P_i` is the projector onto the `i`-th computational basis state.
+
+For single-qubit depolarizing error, it is equivalent to the [`PauliError`](@ref) channel with `px = py = pz = p/4`.
+
+# Fields
+- `n::Int`: the number of qubits
+- `p::RT`: the error probability, must be non-negative and less than or equal to ``4^n/(4^n-1)``    
 """
 struct DepolarizingError{RT<:Real} <: AbstractErrorType
     n::Int
     p::RT
+    function DepolarizingError(n::Int, p::RT) where RT<:Real
+        n ≥ 1 || throw(ArgumentError("n must be at least 1, got $n"))
+        0 ≤ p ≤ 4^n/(4^n-1) || throw(ArgumentError("p must be in [0, 4^n/(4^n-1)] (n = $n), got $p"))
+        new{RT}(n, p)
+    end
 end
 MixedUnitaryChannel(p::DepolarizingError) = MixedUnitaryChannel(PauliError(p))
 quantum_channel(p::DepolarizingError) = DepolarizingChannel(p.n, p.p)
@@ -43,11 +90,23 @@ When applied to a density matrix `ρ`, the error channel is given by:
 ```math
 (1 - (p_x + p_y + p_z))⋅ρ + p_x⋅X⋅ρ⋅X + p_y⋅Y⋅ρ⋅Y  + p_z⋅Z⋅ρ⋅Z
 ```
+
+# Fields
+- `px::RT`: the error probability of Pauli X, must be non-negative
+- `py::RT`: the error probability of Pauli Y, must be non-negative
+- `pz::RT`: the error probability of Pauli Z, must be non-negative
 """
 struct PauliError{RT<:Real} <: AbstractErrorType
     px::RT
     py::RT
     pz::RT
+    function PauliError(px::RT, py::RT, pz::RT) where RT<:Real
+        px ≥ 0 || throw(ArgumentError("px must be non-negative, got $px"))
+        py ≥ 0 || throw(ArgumentError("py must be non-negative, got $py"))
+        pz ≥ 0 || throw(ArgumentError("pz must be non-negative, got $pz"))
+        px + py + pz ≤ 1 || throw(ArgumentError("sum of error probability is larger than 1, got $px + $py + $pz"))
+        new{RT}(px, py, pz)
+    end
 end
 # convert error types to pauli error
 PauliError(err::BitFlipError{T}) where T = PauliError(err.p, zero(T), zero(T))
@@ -76,18 +135,6 @@ When applied to a density matrix `ρ`, the error channel is given by:
 (1 - p_0 - p_1)⋅ρ + p_0⋅(P_0⋅ρ⋅P_0 + P_d⋅ρ⋅P_d') + p_1⋅(P_1⋅ρ⋅P_1 + P_u⋅ρ⋅P_u')
 ```
 where `P_0` and `P_1` are the projectors onto the 0 and 1 eigenstates of the Pauli Z operator, and `P_u` and `P_d` are the projectors onto the up and down eigenstates of the Pauli X operator.
-"""
-struct ResetError{RT<:Real} <: AbstractErrorType
-    p0::RT
-    p1::RT
-end
-
-quantum_channel(p::ResetError) = KrausChannel(p)
-
-
-# https://docs.pennylane.ai/en/stable/code/api/pennylane.ResetError.html
-"""
-Single-qubit Reset error channel.
 
 This channel is modelled by the following Kraus matrices:
 ```math
@@ -104,6 +151,20 @@ where ``p_0 \\in [0,1]`` is the probability of a reset to 0, and ``p_1 \\in [0,1
 ### Note
 The Kraus operators are not unique, and the above is not the simplest form.
 """
+struct ResetError{RT<:Real} <: AbstractErrorType
+    p0::RT
+    p1::RT
+    function ResetError(p0::RT, p1::RT2) where {RT<:Real, RT2<:Real}
+        T = promote_type(RT, RT2)
+        p0 ≥ 0 || throw(ArgumentError("p0 must be non-negative, got $p0"))
+        p1 ≥ 0 || throw(ArgumentError("p1 must be non-negative, got $p1"))
+        p0 + p1 ≤ 1 || throw(ArgumentError("sum of error probability is larger than 1, got $p0 + $p1"))
+        new{T}(T(p0), T(p1))
+    end
+end
+quantum_channel(p::ResetError) = KrausChannel(p)
+
+# https://docs.pennylane.ai/en/stable/code/api/pennylane.ResetError.html
 function KrausChannel(err::ResetError)
     p0, p1 = err.p0, err.p1
     p0 + p1 ≤ 1 || throw(ArgumentError("sum of error probability is larger than 1"))
@@ -118,6 +179,187 @@ function KrausChannel(err::ResetError)
     end
     return KrausChannel(operators)
 end
+
+"""
+    ThermalRelaxationError{RT<:Real} <: AbstractErrorType
+    ThermalRelaxationError(T1, T2, time, excited_state_population=zero(RT))
+
+Thermal relaxation error channel with error probabilities `T1`, `T2`, `time`, and `excited_state_population`.
+It can be viewed as a special case of [`PhaseAmplitudeDampingError`](@ref) with:
+```math
+\\begin{align}
+a = 1 - \\exp\\left(-\\frac{t}{T_1}\\right)\\\\
+b = 1 - \\exp\\left(-\\frac{t}{T_{\\phi}}\\right)\\\\
+\\end{align}
+```
+where ``T_{\\phi} = \\frac{T_1 T_2}{2 T_1 - T_2}``.
+
+# Fields
+- `T1::RT`: the T1 time (energy relaxation time), must be positive
+- `T2::RT`: the T2 time (dephasing time), must be positive and satisfy `T2 ≤ 2T1`.
+  - If `T2 ≤ T1` the error can be expressed as a mixed reset and unitary error channel.
+  - If `T1 < T2 ≤ 2T1` the error must be expressed as a general non-unitary Kraus error channel.
+- `time::RT`: the duration of the error, must be non-negative
+- `excited_state_population::RT`: the probability of state |1⟩ at thermal equilibrium
+"""
+struct ThermalRelaxationError{RT<:Real} <: AbstractErrorType
+    T1::RT
+    T2::RT
+    time::RT
+    excited_state_population::RT
+    function ThermalRelaxationError(T1::RT, T2::RT, time::RT2, excited_state_population::RT3=zero(RT)) where {RT<:Real, RT2<:Real, RT3<:Real}
+        T = promote_type(RT, RT2, RT3)
+        T1 > 0 || throw(ArgumentError("T1 must be positive, got $T1"))
+        T2 > 0 || throw(ArgumentError("T2 must be positive, got $T2"))
+        T2 ≤ 2T1 || throw(ArgumentError("T2 must be less than or equal to 2T1, got $T2"))
+        time ≥ 0 || throw(ArgumentError("time must be non-negative, got $time"))
+        0 ≤ excited_state_population ≤ 1 || throw(ArgumentError("excited_state_population must be in [0, 1], got $excited_state_population"))
+        new{T}(T(T1), T(T2), T(time), T(excited_state_population))
+    end
+end
+quantum_channel(err::ThermalRelaxationError) = KrausChannel(err)
+
+# Ref: https://quantumcomputing.stackexchange.com/questions/27017/what-is-the-concrete-difference-between-qiskit-thermal-relaxation-error-and-phas
+function KrausChannel(err::ThermalRelaxationError)
+    T1, T2, time = err.T1, err.T2, err.time
+    Tϕ = (T1*T2)/(2 * T1 - T2)
+    amplitude = 1 - exp(-time/T1)
+    phase = 1 - exp(-time/Tϕ)
+    KrausChannel(PhaseAmplitudeDampingError(amplitude, phase, err.excited_state_population))
+end
+
+"""
+    PhaseAmplitudeDampingError{RT<:Real} <: AbstractErrorType
+    PhaseAmplitudeDampingError(amplitude::RT, phase::RT, excited_state_population::RT2=zero(RT)) where {RT<:Real, RT2<:Real}
+
+Phase amplitude and phase damping error channel, described by the following Kraus matrices:
+
+```math
+A_0 = √(1 - p_1) * \\begin{bmatrix} 1 & 0 \\\\ 0 & √(1 - a - b) \\end{bmatrix}
+A_1 = √(1 - p_1) * \\begin{bmatrix} 0 & √a \\\\ 0 & 0 \\end{bmatrix}
+A_2 = √(1 - p_1) * \\begin{bmatrix} 0 & 0 \\\\ 0 & √b \\end{bmatrix}
+B_0 = √p_1 * \\begin{bmatrix} √(1 - a - b) & 0 \\\\ 0 & 1 \\end{bmatrix}
+B_1 = √p_1 * \\begin{bmatrix} 0 & 0 \\\\ √a & 0 \\end{bmatrix}
+B_2 = √p_1 * \\begin{bmatrix} √b & 0 \\\\ 0 & 0 \\end{bmatrix}
+```
+
+where ``a`` = `amplitude`, ``b`` = `phase` and ``p_1`` = `excited_state_population`. The equilibrium state is given by:
+```math
+ρ_0 = \\begin{bmatrix} 1-p_1 & 0 \\\\ 0 & p_1 \\end{bmatrix}
+```
+
+# Fields
+- `amplitude::RT`: the amplitude damping error parameter, must be non-negative
+- `phase::RT`: the phase damping error parameter, must be non-negative and satisfy `phase + amplitude ≤ 1`
+- `excited_state_population::RT`: the probability of state |1⟩ at thermal equilibrium, must be in [0, 1]
+"""
+struct PhaseAmplitudeDampingError{RT<:Real} <: AbstractErrorType
+    amplitude::RT
+    phase::RT
+    excited_state_population::RT
+    function PhaseAmplitudeDampingError(amplitude::RT, phase::RT, excited_state_population::RT2=zero(RT)) where {RT<:Real, RT2<:Real}
+        T = promote_type(RT, RT2)
+        0 ≤ amplitude ≤ 1 || throw(ArgumentError("amplitude must be in [0, 1], got $amplitude"))
+        0 ≤ phase ≤ 1 || throw(ArgumentError("phase must be in [0, 1], got $phase"))
+        phase + amplitude ≤ 1 || throw(ArgumentError("phase + amplitude must be less than or equal to 1, got $phase + $amplitude"))
+        0 ≤ excited_state_population ≤ 1 || throw(ArgumentError("excited_state_population must be in [0, 1], got $excited_state_population"))
+        new{T}(T(amplitude), T(phase), T(excited_state_population))
+    end
+end
+
+quantum_channel(err::PhaseAmplitudeDampingError) = KrausChannel(err)
+function KrausChannel(err::PhaseAmplitudeDampingError{T}) where T
+    CT = Complex{T}
+    a, b, p1 = err.amplitude, err.phase, err.excited_state_population
+    blocks = AbstractBlock{2}[]
+    if !(p1 ≈ 1)
+        # dampling operators to 0 state
+        push!(blocks, matblock(sqrt(1 - p1) * CT[1 0; 0 sqrt(1 - a - b)]; tag = "A0"))
+        if !iszero(a)
+            push!(blocks, matblock(sqrt(1 - p1) * CT[0 sqrt(a); 0 0]; tag = "A1"))
+        end
+        if !iszero(b)
+            push!(blocks, matblock(sqrt(1 - p1) * CT[0 0; 0 sqrt(b)]; tag = "A2"))
+        end
+    end
+    if !(p1 ≈ 0)
+        # dampling operators to 1 state
+        push!(blocks, matblock(sqrt(p1) * CT[sqrt(1 - a - b) 0; 0 1]; tag = "B0"))
+        if !iszero(a)
+            push!(blocks, matblock(sqrt(p1) * CT[0 0; sqrt(a) 0]; tag = "B1"))
+        end
+        if !iszero(b)
+            push!(blocks, matblock(sqrt(p1) * CT[sqrt(b) 0; 0 0]; tag = "B2"))
+        end
+    end
+    return KrausChannel(blocks)
+end
+
+"""
+    PhaseDampingError{RT<:Real} <: AbstractErrorType
+    PhaseDampingError(phase::RT) where RT<:Real
+
+Phase damping error channel, described by the following Kraus matrices:
+
+```math
+A_0 = \\begin{bmatrix} 1 & 0 \\\\ 0 & √(1 - b) \\end{bmatrix}
+A_2 = \\begin{bmatrix} 0 & 0 \\\\ 0 & √b \\end{bmatrix}
+```
+
+where ``b`` = `phase`.
+The equilibrium state is given by:
+```math
+ρ_0 = \\begin{bmatrix} ρ_{00} & 0 \\\\ 0 & ρ_{11} \\end{bmatrix}
+```
+where ``ρ_{00}`` and ``ρ_{11}`` are the diagonal elements of the input density matrix.
+
+# Fields
+- `phase::RT`: the phase damping error parameter, must be non-negative
+"""
+struct PhaseDampingError{RT<:Real} <: AbstractErrorType
+    phase::RT
+    function PhaseDampingError(phase::RT) where RT<:Real
+        0 ≤ phase ≤ 1 || throw(ArgumentError("phase must be in [0, 1], got $phase"))
+        new{RT}(phase)
+    end
+end
+quantum_channel(err::PhaseDampingError) = KrausChannel(err)
+KrausChannel(err::PhaseDampingError{T}) where T = KrausChannel(PhaseAmplitudeDampingError(zero(T), err.phase, zero(T)))
+
+"""
+    AmplitudeDampingError{RT<:Real} <: AbstractErrorType
+    AmplitudeDampingError(amplitude::RT, excited_state_population::RT2=zero(RT)) where {RT<:Real, RT2<:Real}
+
+Amplitude damping error channel, described by the following Kraus matrices:
+
+```math
+A_0 = √(1 - p_1) * \\begin{bmatrix} 1 & 0 \\\\ 0 & √(1 - a) \\end{bmatrix}
+A_1 = √(1 - p_1) * \\begin{bmatrix} 0 & √a \\\\ 0 & 0 \\end{bmatrix}
+B_0 = √p_1 * \\begin{bmatrix} √(1 - a) & 0 \\\\ 0 & 1 \\end{bmatrix}
+B_1 = √p_1 * \\begin{bmatrix} 0 & 0 \\\\ √a & 0 \\end{bmatrix}
+```
+
+where ``a`` = `amplitude` and ``p_1`` = `excited_state_population`. The equilibrium state is given by:
+```math
+ρ_0 = \\begin{bmatrix} 1-p_1 & 0 \\\\ 0 & p_1 \\end{bmatrix}
+```
+
+# Fields
+- `amplitude::RT`: the amplitude damping error parameter, must be non-negative
+- `excited_state_population::RT`: the probability of state |1⟩ at thermal equilibrium, must be non-negative and less than or equal to 1
+"""
+struct AmplitudeDampingError{RT<:Real} <: AbstractErrorType
+    amplitude::RT
+    excited_state_population::RT
+    function AmplitudeDampingError(amplitude::RT, excited_state_population::RT2=zero(RT)) where {RT<:Real, RT2<:Real}
+        T = promote_type(RT, RT2)
+        0 ≤ amplitude ≤ 1 || throw(ArgumentError("amplitude must be in [0, 1], got $amplitude"))
+        0 ≤ excited_state_population ≤ 1 || throw(ArgumentError("excited_state_population must be in [0, 1], got $excited_state_population"))
+        new{T}(T(amplitude), T(excited_state_population))
+    end
+end
+quantum_channel(err::AmplitudeDampingError) = KrausChannel(err)
+KrausChannel(err::AmplitudeDampingError{T}) where T = KrausChannel(PhaseAmplitudeDampingError(err.amplitude, zero(T), err.excited_state_population))
 
 # convert error types to superop
 SuperOp(::Type{T}, x::AbstractErrorType) where T = SuperOp(T, quantum_channel(x))

--- a/lib/YaoBlocks/test/channel/errortypes.jl
+++ b/lib/YaoBlocks/test/channel/errortypes.jl
@@ -118,3 +118,90 @@ end
     @test mat(reset_kraus.operators[4]) ≈ [0.0 0.0; 0.0 sqrt(0.1)]
     @test mat(reset_kraus.operators[5]) ≈ [0.0 sqrt(0.1); 0.0 0.0]
 end
+
+@testset "super operators" begin
+    # bit flip
+    p_error = 0.05
+    bit_flip = BitFlipError(p_error)
+    @test SuperOp(bit_flip).superop ≈ [0.95 0.0 0.0 0.05;
+        0.0 0.95 0.05 0.0;
+        0.0 0.05 0.95 0.0;
+        0.05 0.0 0.0 0.95]
+
+    # phase flip
+    p_error = 0.05
+    phase_flip = PhaseFlipError(p_error)
+    @test SuperOp(phase_flip).superop ≈ [1.0 0.0 0.0 0.0;
+        0.0 0.9 0.0 0.0;
+        0.0 0.0 0.9 0.0;
+        0.0 0.0 0.0 1.0]
+
+    # depolarizing
+    p_error = 0.1
+    depolarizing = DepolarizingError(1, p_error)
+    @test SuperOp(depolarizing).superop ≈ [0.95 0.0 0.0 0.05;
+        0.0 0.9 0.0 0.0;
+        0.0 0.0 0.9 0.0;
+        0.05 0.0 0.0 0.95]
+
+    # thermal relaxation
+    T1 = 100.0
+    T2 = 200.0
+    time = 1.0
+    excited_state_population = 0.0
+    thermal_relaxation = ThermalRelaxationError(T1, T2, time, excited_state_population)
+    @test SuperOp(thermal_relaxation).superop ≈ [1.0 0.0 0.0 0.00995017;
+        0.0 0.99501248 0.0 0.0;
+        0.0 0.0 0.99501248 0.0;
+        0.0 0.0 0.0 0.99004983]
+
+    # coherent error
+    block = X
+    coherent_error = CoherentError(block)
+    @test SuperOp(coherent_error).superop ≈ [0.0 0.0 0.0 1.0;
+        0.0 0.0 1.0 0.0;
+        0.0 1.0 0.0 0.0;
+        1.0 0.0 0.0 0.0]
+
+    # pauli error
+    px, py, pz = 0.1, 0.0, 0.0
+    pauli_error = PauliError(px, py, pz)
+    @test SuperOp(pauli_error).superop ≈ [0.9 0.0 0.0 0.1;
+        0.0 0.9 0.1 0.0;
+        0.0 0.1 0.9 0.0;
+        0.1 0.0 0.0 0.9]
+
+    # amplitude damping
+    param_amp = 0.1
+    amplitude_damping = AmplitudeDampingError(param_amp)
+    @test SuperOp(amplitude_damping).superop ≈ [1.0 0.0 0.0 0.1;
+        0.0 0.9486833 0.0 0.0;
+        0.0 0.0 0.9486833 0.0;
+        0.0 0.0 0.0 0.9]
+
+    # phase damping
+    param_phase = 0.1
+    phase_damping = PhaseDampingError(param_phase)
+    @test SuperOp(phase_damping).superop ≈ [1.0 0.0 0.0 0.0;
+        0.0 0.9486833 0.0 0.0;
+        0.0 0.0 0.9486833 0.0;
+        0.0 0.0 0.0 1.0]
+
+    # phase amplitude damping
+    param_amp = 0.1
+    param_phase = 0.05
+    excited_state_population = 0.0
+    phase_amplitude_damping = PhaseAmplitudeDampingError(param_amp, param_phase, excited_state_population)
+    @test SuperOp(phase_amplitude_damping).superop ≈ [1.0 0.0 0.0 0.1;
+        0.0 0.92195445 0.0 0.0;
+        0.0 0.0 0.92195445 0.0;
+        0.0 0.0 0.0 0.9]
+
+    # phase amplitude damping with excited state population
+    excited_state_population = 0.1
+    phase_amplitude_damping_excited = PhaseAmplitudeDampingError(param_amp, param_phase, excited_state_population)
+    @test SuperOp(phase_amplitude_damping_excited).superop ≈ [0.99 0.0 0.0 0.09;
+        0.0 0.92195445 0.0 0.0;
+        0.0 0.0 0.92195445 0.0;
+        0.01 0.0 0.0 0.91]
+end


### PR DESCRIPTION
More error types are added and compared with qiskit.

```bash
$ python noiseinspect.py

1. Depolarizing Error (p=0.1, num_qubits=1):
SuperOp([[0.95+0.j, 0.  +0.j, 0.  +0.j, 0.05+0.j],
         [0.  +0.j, 0.9 +0.j, 0.  +0.j, 0.  +0.j],
         [0.  +0.j, 0.  +0.j, 0.9 +0.j, 0.  +0.j],
         [0.05+0.j, 0.  +0.j, 0.  +0.j, 0.95+0.j]],
        input_dims=(2,), output_dims=(2,))

2. Thermal Relaxation Error (T1=100, T2=200, time=1):
SuperOp([[1.        +0.j, 0.        +0.j, 0.        +0.j, 0.00995017+0.j],
         [0.        +0.j, 0.99501248+0.j, 0.        +0.j, 0.        +0.j],
         [0.        +0.j, 0.        +0.j, 0.99501248+0.j, 0.        +0.j],
         [0.        +0.j, 0.        +0.j, 0.        +0.j, 0.99004983+0.j]],
        input_dims=(2,), output_dims=(2,))

3. Coherent Unitary Error (X gate):
SuperOp([[0.+0.j, 0.+0.j, 0.+0.j, 1.+0.j],
         [0.+0.j, 0.+0.j, 1.+0.j, 0.+0.j],
         [0.+0.j, 1.+0.j, 0.+0.j, 0.+0.j],
         [1.+0.j, 0.+0.j, 0.+0.j, 0.+0.j]],
        input_dims=(2,), output_dims=(2,))

4. Pauli Error (X with probability 0.1):
SuperOp([[0.9+0.j, 0. +0.j, 0. +0.j, 0.1+0.j],
         [0. +0.j, 0.9+0.j, 0.1+0.j, 0. +0.j],
         [0. +0.j, 0.1+0.j, 0.9+0.j, 0. +0.j],
         [0.1+0.j, 0. +0.j, 0. +0.j, 0.9+0.j]],
        input_dims=(2,), output_dims=(2,))

5. Amplitude Damping Error (param_amp=0.1):
SuperOp([[1.       +0.j, 0.       +0.j, 0.       +0.j, 0.1      +0.j],
         [0.       +0.j, 0.9486833+0.j, 0.       +0.j, 0.       +0.j],
         [0.       +0.j, 0.       +0.j, 0.9486833+0.j, 0.       +0.j],
         [0.       +0.j, 0.       +0.j, 0.       +0.j, 0.9      +0.j]],
        input_dims=(2,), output_dims=(2,))

6. Phase Damping Error (param_phase=0.1):
SuperOp([[1.       +0.j, 0.       +0.j, 0.       +0.j, 0.       +0.j],
         [0.       +0.j, 0.9486833+0.j, 0.       +0.j, 0.       +0.j],
         [0.       +0.j, 0.       +0.j, 0.9486833+0.j, 0.       +0.j],
         [0.       +0.j, 0.       +0.j, 0.       +0.j, 1.       +0.j]],
        input_dims=(2,), output_dims=(2,))

7. Phase-Amplitude Damping Error (param_amp=0.1, param_phase=0.05):
SuperOp([[1.        +0.j, 0.        +0.j, 0.        +0.j, 0.1       +0.j],
         [0.        +0.j, 0.92195445+0.j, 0.        +0.j, 0.        +0.j],
         [0.        +0.j, 0.        +0.j, 0.92195445+0.j, 0.        +0.j],
         [0.        +0.j, 0.        +0.j, 0.        +0.j, 0.9       +0.j]],
        input_dims=(2,), output_dims=(2,))
```

The Qiskit script is as below:
```python
from qiskit_aer.noise import depolarizing_error, thermal_relaxation_error, ReadoutError, coherent_unitary_error, pauli_error, amplitude_damping_error, phase_damping_error, phase_amplitude_damping_error
from qiskit.quantum_info import SuperOp

# 1. Depolarizing Error
print("1. Depolarizing Error (p=0.1, num_qubits=1):")
error = depolarizing_error(0.1, 1)
print(SuperOp(error))
print()

# 2. Thermal Relaxation Error
print("2. Thermal Relaxation Error (T1=100, T2=200, time=1):")
error = thermal_relaxation_error(100, 200, 1)
print(SuperOp(error))
print()

# 3. Coherent Unitary Error
print("3. Coherent Unitary Error (X gate):")
error = coherent_unitary_error([[0, 1], [1, 0]])
print(SuperOp(error))
print()

# 4. Pauli Error
print("4. Pauli Error (X with probability 0.1):")
error = pauli_error([('X', 0.1), ('I', 0.9)])
print(SuperOp(error))
print()

# 5. Amplitude Damping Error
print("5. Amplitude Damping Error (param_amp=0.1):")
error = amplitude_damping_error(0.1)
print(SuperOp(error))
print()

# 6. Phase Damping Error
print("6. Phase Damping Error (param_phase=0.1):")
error = phase_damping_error(0.1)
print(SuperOp(error))
print()

# 7. Phase-Amplitude Damping Error
print("7. Phase-Amplitude Damping Error (param_amp=0.1, param_phase=0.05):")
error = phase_amplitude_damping_error(0.1, 0.05)
print(SuperOp(error))
print()


# 8. Phase-Amplitude Damping Error with excited state population
print("8. Phase-Amplitude Damping Error with excited state population (param_amp=0.1, param_phase=0.05, excited_state_population=0.1):")
error = phase_amplitude_damping_error(0.1, 0.05, 0.1)
print(SuperOp(error))
print()
```