### PR TITLE
Generate tensor network on density matrix basis and Pauli basis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,31 +1,47 @@
 JL = julia --project
 
-default: init test
-
 init:
-	$(JL) -e 'using Pkg; Pkg.develop([Pkg.PackageSpec(path = joinpath("lib", pkg)) for pkg in ["YaoArrayRegister", "YaoBlocks", "YaoSym", "YaoPlots", "YaoAPI", "YaoToEinsum"]]); Pkg.precompile()'
-init-docs:
-	$(JL) -e 'using Pkg; Pkg.activate("docs"); Pkg.develop([Pkg.PackageSpec(path = joinpath("lib", pkg)) for pkg in ["YaoArrayRegister", "YaoBlocks", "YaoSym", "YaoPlots", "YaoAPI", "YaoToEinsum"]]); Pkg.precompile()'
+	echo "Initializing YaoAPI"; \
+	$(JL) -e "using Pkg; Pkg.activate(\"lib/YaoAPI\"); Pkg.instantiate()"; \
+	echo "Initializing YaoArrayRegister"; \
+	$(JL) -e "using Pkg; Pkg.activate(\"lib/YaoArrayRegister\"); Pkg.develop(path=\"lib/YaoAPI\"); Pkg.instantiate()"; \
+	echo "Initializing YaoBlocks"; \
+	$(JL) -e "using Pkg; Pkg.activate(\"lib/YaoBlocks\"); Pkg.develop([Pkg.PackageSpec(path=\"lib/YaoAPI\"), Pkg.PackageSpec(path=\"lib/YaoArrayRegister\")]); Pkg.instantiate()"; \
+	echo "Initializing YaoSym"; \
+	$(JL) -e "using Pkg; Pkg.activate(\"lib/YaoSym\"); Pkg.develop([Pkg.PackageSpec(path=\"lib/YaoArrayRegister\"), Pkg.PackageSpec(path=\"lib/YaoBlocks\")]); Pkg.instantiate()"; \
+	echo "Initializing YaoPlots"; \
+	$(JL) -e "using Pkg; Pkg.activate(\"lib/YaoPlots\"); Pkg.develop([Pkg.PackageSpec(path=\"lib/YaoBlocks\"), Pkg.PackageSpec(path=\"lib/YaoArrayRegister\")]); Pkg.instantiate()"; \
+	echo "Initializing YaoToEinsum"; \
+	$(JL) -e "using Pkg; Pkg.activate(\"lib/YaoToEinsum\"); Pkg.develop([Pkg.PackageSpec(path=\"lib/YaoBlocks\")]); Pkg.instantiate()"; \
+	echo "Initializing Yao"; \
+	$(JL) -e "using Pkg; Pkg.activate(\".\"); Pkg.develop([Pkg.PackageSpec(path=\"lib/YaoAPI\"), Pkg.PackageSpec(path=\"lib/YaoArrayRegister\"), Pkg.PackageSpec(path=\"lib/YaoBlocks\"), Pkg.PackageSpec(path=\"lib/YaoSym\"), Pkg.PackageSpec(path=\"lib/YaoPlots\"), Pkg.PackageSpec(path=\"lib/YaoToEinsum\")]); Pkg.instantiate()"; \
+	echo "Initializing docs"; \
+	$(JL) -e "using Pkg; Pkg.activate(\"docs\"); Pkg.develop([Pkg.PackageSpec(path = \"lib/YaoAPI\"), Pkg.PackageSpec(path = \"lib/YaoArrayRegister\"), Pkg.PackageSpec(path = \"lib/YaoBlocks\"), Pkg.PackageSpec(path = \"lib/YaoSym\"), Pkg.PackageSpec(path = \"lib/YaoPlots\"), Pkg.PackageSpec(path = \"lib/YaoToEinsum\"), Pkg.PackageSpec(path = \".\")]); Pkg.instantiate()"; \
 
 update:
-	$(JL) -e 'using Pkg; Pkg.update(); Pkg.precompile()'
-update-docs:
-	$(JL) -e 'using Pkg; Pkg.activate("docs"); Pkg.update(); Pkg.precompile()'
+	echo "Updating YaoAPI"; \
+	$(JL) -e "using Pkg; Pkg.activate(\"lib/YaoAPI\"); Pkg.update()"; \
+	echo "Updating YaoArrayRegister"; \
+	$(JL) -e "using Pkg; Pkg.activate(\"lib/YaoArrayRegister\"); Pkg.update()"; \
+	echo "Updating YaoBlocks"; \
+	$(JL) -e "using Pkg; Pkg.activate(\"lib/YaoBlocks\"); Pkg.update()"; \
+	echo "Updating YaoSym"; \
+	$(JL) -e "using Pkg; Pkg.activate(\"lib/YaoSym\"); Pkg.update()"; \
+	echo "Updating YaoPlots"; \
+	$(JL) -e "using Pkg; Pkg.activate(\"lib/YaoPlots\"); Pkg.update()"; \
+	echo "Updating YaoToEinsum"; \
+	$(JL) -e "using Pkg; Pkg.activate(\"lib/YaoToEinsum\"); Pkg.update()"; \
+	echo "Updating Yao"; \
+	$(JL) -e "using Pkg; Pkg.activate(\".\"); Pkg.update()"; \
+	echo "Updating docs"; \
+	$(JL) -e "using Pkg; Pkg.activate(\"docs\"); Pkg.update()"; \
 
-test-Yao:
-	$(JL) -e 'using Pkg; Pkg.test("Yao")'
 test-CuYao:
 	$(JL) -e 'using Pkg; Pkg.activate("ext/CuYao/test"); Pkg.develop(path="."); Pkg.update()'
 	$(JL) -e 'using Pkg; Pkg.activate("ext/CuYao/test"); include("ext/CuYao/test/runtests.jl")'
 
-test-%:
-	$(JL) -e 'using Pkg; Pkg.test("$*")'
-
 test:
-	$(JL) -e 'using Pkg; Pkg.test(["YaoAPI", "YaoArrayRegister", "YaoBlocks", "YaoSym", "YaoPlots", "Yao", "YaoToEinsum"])'
-
-coverage:
-	$(JL) -e 'using Pkg; Pkg.test(["YaoAPI", "YaoArrayRegister", "YaoBlocks", "YaoSym", "YaoPlots", "Yao", "YaoToEinsum"]; coverage=true)'
+	$(JL) -e "using Pkg; Pkg.test([\"YaoAPI\", \"YaoArrayRegister\", \"YaoBlocks\", \"YaoSym\", \"YaoPlots\", \"Yao\", \"YaoToEinsum\"]; coverage=$${coverage:-false})"
 
 servedocs:
 	$(JL) -e 'using Pkg; Pkg.activate("docs"); using LiveServer; servedocs(;skip_dirs=["docs/src/assets", "docs/src/generated"])'
@@ -34,4 +50,4 @@ clean:
 	rm -rf docs/build
 	find . -name "*.cov" -type f -print0 | xargs -0 /bin/rm -f
 
-.PHONY: init test
+.PHONY: init test update update-docs servedocs clean test-CuYao

--- a/lib/YaoArrayRegister/src/density_matrix.jl
+++ b/lib/YaoArrayRegister/src/density_matrix.jl
@@ -216,6 +216,7 @@ end
 $(TYPEDSIGNATURES)
 """
 function Base.join(r0::DensityMatrix{D}, rs::DensityMatrix{D}...) where {D}
+    length(rs) == 0 && return r0
     st = kron(state(r0), state.(rs)...)
     return DensityMatrix{D}(st)
 end

--- a/lib/YaoBlocks/src/treeutils/optimise.jl
+++ b/lib/YaoBlocks/src/treeutils/optimise.jl
@@ -47,6 +47,7 @@ function to_basictypes end
 to_basictypes(block::PrimitiveBlock) = block
 to_basictypes(block::MixedUnitaryChannel) = block
 to_basictypes(block::KrausChannel) = block
+to_basictypes(block::DepolarizingChannel) = block
 to_basictypes(block::SuperOp) = block
 function to_basictypes(block::AbstractBlock)
     throw(NotImplementedError(:to_basictypes, typeof(block)))

--- a/lib/YaoBlocks/test/treeutils/optimise.jl
+++ b/lib/YaoBlocks/test/treeutils/optimise.jl
@@ -68,6 +68,16 @@ end
     @test to_basictypes(put(5, 3 => X) |> cache) == put(5, 3 => X)
     @test to_basictypes(Daggered(X)) == Daggered(X)
 
+    # channels
+    c0 = DepolarizingChannel(5, 0.1)
+    c1 = MixedUnitaryChannel([X, Y], [0.1, 0.9])
+    c2 = KrausChannel([0.3*X, 0.1*Y])
+    c3 = SuperOp(X)
+    @test to_basictypes(c0) == c0
+    @test to_basictypes(c1) == c1
+    @test to_basictypes(c2) == c2
+    @test to_basictypes(c3) == c3
+
     # tobasic_recursive
     sub = chain(
         5,

--- a/lib/YaoToEinsum/src/Core.jl
+++ b/lib/YaoToEinsum/src/Core.jl
@@ -1,3 +1,8 @@
+abstract type AbstractMappingMode end
+struct DensityMatrixMode <: AbstractMappingMode end
+struct PauliBasisMode <: AbstractMappingMode end
+struct VectorMode <: AbstractMappingMode end
+
 """
     TensorNetwork
 

--- a/lib/YaoToEinsum/src/YaoToEinsum.jl
+++ b/lib/YaoToEinsum/src/YaoToEinsum.jl
@@ -1,6 +1,7 @@
 module YaoToEinsum
 
 using YaoBlocks, YaoBlocks.YaoArrayRegister, OMEinsum
+using YaoBlocks: sparse
 using LinearAlgebra
 
 export yao2einsum, DensityMatrixMode, PauliBasisMode, VectorMode
@@ -9,5 +10,6 @@ export TreeSA
 
 include("Core.jl")
 include("circuitmap.jl")
+include("densitymatrix.jl")
 
 end

--- a/lib/YaoToEinsum/src/YaoToEinsum.jl
+++ b/lib/YaoToEinsum/src/YaoToEinsum.jl
@@ -3,7 +3,7 @@ module YaoToEinsum
 using YaoBlocks, YaoBlocks.YaoArrayRegister, OMEinsum
 using LinearAlgebra
 
-export yao2einsum
+export yao2einsum, DensityMatrixMode, PauliBasisMode, VectorMode
 export TensorNetwork, optimize_code, contraction_complexity, contract
 export TreeSA
 

--- a/lib/YaoToEinsum/src/densitymatrix.jl
+++ b/lib/YaoToEinsum/src/densitymatrix.jl
@@ -1,6 +1,12 @@
+# basis ordering:
+# n = 1: [1, -1] => [1', -1']
+# n = 2: [1, 2, -1, -2] => [1', 2', -1', -2']; however, after kron, the basis is [1, -1, 2, -2] => [1', -1', 2', -2']
+# n = 2: [1, 2, 3, -1, -2, -3] => [1', 2', 3', -1', -2', -3']; however, after kron, the basis is [1, -1, 2, -2, 3, -3] => [1', -1', 2', -2', 3', -3']
+# So, we need to reorder the basis after kron.
 function pauli_basis_transformer(::Type{T}, n::Int) where {T}
     PAULI_BASIS_TRANSFORM = sparse(T[1 0 0 1; 0 1 -im 0; 0 1 im 0; 1 0 0 -1])
-    return reduce(YaoBlocks.fastkron, [PAULI_BASIS_TRANSFORM for _=1:n])
+    # TODO: verify the ordering
+    return YaoBlocks.reorder(reduce(YaoBlocks.fastkron, [PAULI_BASIS_TRANSFORM for _=1:n]), [1:2:2n..., 2:2:2n...])
 end
 
 function to_pauli_basis(rho::DensityMatrix{2, T}) where {T}

--- a/lib/YaoToEinsum/src/densitymatrix.jl
+++ b/lib/YaoToEinsum/src/densitymatrix.jl
@@ -1,0 +1,23 @@
+function pauli_basis_transformer(::Type{T}, n::Int) where {T}
+    PAULI_BASIS_TRANSFORM = sparse(T[1 0 0 1; 0 1 -im 0; 0 1 im 0; 1 0 0 -1])
+    return reduce(YaoBlocks.fastkron, [PAULI_BASIS_TRANSFORM for _=1:n])
+end
+
+function to_pauli_basis(rho::DensityMatrix{2, T}) where {T}
+    n = nqubits(rho)
+    U = pauli_basis_transformer(T, n)
+    return DensityMatrix{2}(reshape(U * vec(rho.state) ./ sqrt(2^n), 2^n, 2^n))
+end
+
+function to_pauli_basis(op::SuperOp{2, T}) where {T}
+    n = nqubits(op)
+    U = pauli_basis_transformer(T, n)
+    return SuperOp{2}(U * op.superop * U' ./ 2^n)
+end
+
+# observables in pauli basis are similar to bra.
+function to_pauli_basis_observable(mat::AbstractMatrix{T}) where {T}
+    n = YaoBlocks.log2i(size(mat, 1))
+    U = pauli_basis_transformer(T, n)
+    return reshape(transpose(vec(transpose(mat))) * U' ./ sqrt(2^n), 2^n, 2^n)
+end

--- a/lib/YaoToEinsum/src/paulibasis.jl
+++ b/lib/YaoToEinsum/src/paulibasis.jl
@@ -1,0 +1,3 @@
+function to_pauli_basis(mat::AbstractMatrix)
+    error("not implemented")
+end

--- a/lib/YaoToEinsum/src/paulibasis.jl
+++ b/lib/YaoToEinsum/src/paulibasis.jl
@@ -1,3 +1,0 @@
-function to_pauli_basis(mat::AbstractMatrix)
-    error("not implemented")
-end

--- a/lib/YaoToEinsum/test/circuitmap.jl
+++ b/lib/YaoToEinsum/test/circuitmap.jl
@@ -370,4 +370,11 @@ end
     expected = expect(op, zero_state(ComplexF64, 5; nlevel=3) |> c)
     @test res.code(res.tensors...; size_info=uniformsize(res.code, 3))[] ≈ expected
 end
+
+@testset "matblock" begin
+    c = matblock(randn(ComplexF64, 4, 4))
+    @test yao2einsum(c) isa TensorNetwork
+    @test contract(yao2einsum(c)) ≈ reshape(mat(c), 2, 2, 2, 2)
+end
+
 end

--- a/lib/YaoToEinsum/test/densitymatrix.jl
+++ b/lib/YaoToEinsum/test/densitymatrix.jl
@@ -20,11 +20,12 @@ using Test, YaoToEinsum, YaoBlocks, YaoBlocks.BitBasis, YaoBlocks.YaoArrayRegist
     @test res1 ≈ res2
 
     # then, we check the channels
+    c0 = quantum_channel(DepolarizingError(5, 0.1))     # DepolarizingChannel
     c1 = quantum_channel(DepolarizingError(1, 0.1))     # DepolarizingChannel
     c2 = quantum_channel(PauliError(0.1, 0.2, 0.3))  # MixedUnitaryChannel
     c3 = quantum_channel(ResetError(0.1, 0.0))            # KrausChannel
     c4 = KrausChannel([matblock(randn(ComplexF64, 4, 4)) for _=1:2])            # KrausChannel
-    circuit = chain(5, [put(5, i=>H) for i=1:5]..., put(5, 1=>c1), put(5, 2=>c2), put(5, 3=>c3), put(5, (4, 5)=>c4), [control(5, 1, i=>Z) for i=2:5]..., repeat(5, H))
+    circuit = chain(5, [put(5, i=>H) for i=1:5]..., c0, put(5, 1=>c1), put(5, 2=>c2), put(5, 3=>c3), put(5, (4, 5)=>c4), [control(5, 1, i=>Z) for i=2:5]..., repeat(5, H))
     network = yao2einsum(circuit, mode=DensityMatrixMode(), initial_state=initial_state, observable=put(5, 1=>Z))
     res1 = contract(network)[]
     res2 = expect(put(5, 1=>Z), density_matrix(reg0) |> circuit)

--- a/lib/YaoToEinsum/test/densitymatrix.jl
+++ b/lib/YaoToEinsum/test/densitymatrix.jl
@@ -56,10 +56,31 @@ end
     res1 = sum(vec(rho1.state) .* vec(to_pauli_basis_observable(mat(op2))))
     res2 = sum(vec(rho2.state) .* vec(mat(op2)))
     @test res1 ≈ res2
+
+    op3 = control(n, 1, 2=>X)
+    rho1 = apply(to_pauli_basis(rho), to_pauli_basis(SuperOp(op3)))
+    rho2 = apply(rho, op3)
+    res1 = sum(vec(rho1.state) .* vec(to_pauli_basis_observable(mat(op3))))
+    res2 = sum(vec(rho2.state) .* vec(mat(op3)))
+    @test res1 ≈ res2
+
+    # check conversion of control gates
+    cblock = control(6, 4, 2=>X)
+    converted = YaoToEinsum._putblock(cblock)
+    @test mat(converted) ≈ mat(cblock)
+
+    # check conversion of observable
+    op4 = put(n, 1=>X)
+    op5 = kron(n, 1=>X, 2=>Y)
+    op6 = repeat(n, X)
+    @test mat(op4) ≈ mat(YaoToEinsum._to_kron(op4))
+    @test mat(op5) ≈ mat(YaoToEinsum._to_kron(op5))
+    @test mat(op6) ≈ mat(YaoToEinsum._to_kron(op6))
 end
 
 @testset "pauli basis mode" begin
-    circuit = chain(5, [put(5, i=>H) for i=1:5]..., [control(5, 1, i=>Z) for i=2:5]..., repeat(5, H))
+    # random input and final state
+    circuit = chain(5, [put(5, i=>H) for i=1:5]..., [put(5, (1, i)=>control(2, 1, 2=>Z)) for i=2:5]..., repeat(5, H))
     initial_state = Dict([i => rand_state(1) for i=1:5])
     reg0 = join([initial_state[5-i+1] for i=1:5]...)
     final_state = Dict([i => rand_state(1) for i=1:5])
@@ -71,7 +92,31 @@ end
     obs = kron(5, [i=>matblock(final_state[i].state * final_state[i].state') for i=1:5]...)
     @test mat(obs) ≈ density_matrix(reg1).state atol=1e-8
     res2 = expect(obs, density_matrix(reg0) |> circuit)
-    @show res0 res1 res2
     @test res0 ≈ res2
     @test res1 ≈ res2
+
+    # random noisy input and final state
+    circuit = chain(5)
+    initial_state = Dict([i => (density_matrix(rand_state(1)) |> YaoBlocks.DepolarizingChannel(1, 0.1)) for i=1:5])
+    reg0 = join([initial_state[5-i+1] for i=1:5]...)
+    # TODO: with depolarizing channel, the final state is incorrect, fix it!
+    final_state = Dict([i => (density_matrix(rand_state(1)) |> YaoBlocks.DepolarizingChannel(1, 0.1)) for i=1:5])
+    reg1 = join([final_state[5-i+1] for i=1:5]...)
+    network0 = yao2einsum(circuit, mode=DensityMatrixMode(), initial_state=initial_state, final_state=final_state)
+    network = yao2einsum(circuit, mode=PauliBasisMode(), initial_state=initial_state, final_state=final_state)
+    res1 = contract(network)[]
+    res0 = contract(network0)[]
+    obs = kron(5, [i=>matblock(final_state[i].state * final_state[i].state') for i=1:5]...)
+    @test mat(obs) ≈ density_matrix(reg1).state atol=1e-8
+    res2 = expect(obs, density_matrix(reg0) |> circuit)
+    @test res0 ≈ res2
+    @test res1 ≈ res2
+
+
+    # observables
+    network0 = yao2einsum(circuit, mode=DensityMatrixMode(), initial_state=initial_state, observable=kron(5, 1=>X))
+    network = yao2einsum(circuit, mode=PauliBasisMode(), initial_state=initial_state, observable=kron(5, 1=>X))
+    res0 = contract(network0)[]
+    res1 = contract(network)[]
+    @test res0 ≈ res1
 end

--- a/lib/YaoToEinsum/test/densitymatrix.jl
+++ b/lib/YaoToEinsum/test/densitymatrix.jl
@@ -1,0 +1,32 @@
+using Test, YaoToEinsum, YaoBlocks, YaoBlocks.BitBasis, YaoBlocks.YaoArrayRegister
+
+@testset "map density matrix" begin
+    circuit = chain(5, [put(5, i=>H) for i=1:5]..., [control(5, 1, i=>Z) for i=2:5]..., repeat(5, H))
+
+    # first, we show the density matrix mode is just the abs2 of the vector mode
+    initial_state = Dict([i => rand_state(1) for i=1:5])
+    reg0 = join([initial_state[5-i+1] for i=1:5]...)
+    final_state = Dict([i => 1 for i=1:5])
+    network = yao2einsum(circuit, mode=DensityMatrixMode(), initial_state=initial_state, final_state=final_state)
+    res1 = contract(network)[]
+    res2 = abs2(product_state(bit"11111")' * (copy(reg0) |> circuit))
+    @test res1 ≈ res2
+
+    # then, we show the density matrix mode supports observables
+    @test_throws AssertionError yao2einsum(circuit, mode=DensityMatrixMode(), initial_state=initial_state, final_state=final_state, observable=put(5, 1=>Z))
+    network = yao2einsum(circuit, mode=DensityMatrixMode(), initial_state=initial_state, observable=put(5, 1=>Z))
+    res1 = contract(network)[]
+    res2 = expect(put(5, 1=>Z), copy(reg0) |> circuit)
+    @test res1 ≈ res2
+
+    # then, we check the channels
+    c1 = quantum_channel(DepolarizingError(1, 0.1))     # DepolarizingChannel
+    c2 = quantum_channel(PauliError(0.1, 0.2, 0.3))  # MixedUnitaryChannel
+    c3 = quantum_channel(ResetError(0.1, 0.0))            # KrausChannel
+    c4 = KrausChannel([matblock(randn(ComplexF64, 4, 4)) for _=1:2])            # KrausChannel
+    circuit = chain(5, [put(5, i=>H) for i=1:5]..., put(5, 1=>c1), put(5, 2=>c2), put(5, 3=>c3), put(5, (4, 5)=>c4), [control(5, 1, i=>Z) for i=2:5]..., repeat(5, H))
+    network = yao2einsum(circuit, mode=DensityMatrixMode(), initial_state=initial_state, observable=put(5, 1=>Z))
+    res1 = contract(network)[]
+    res2 = expect(put(5, 1=>Z), density_matrix(reg0) |> circuit)
+    @test res1 ≈ res2 atol=1e-8
+end

--- a/lib/YaoToEinsum/test/densitymatrix.jl
+++ b/lib/YaoToEinsum/test/densitymatrix.jl
@@ -1,4 +1,5 @@
 using Test, YaoToEinsum, YaoBlocks, YaoBlocks.BitBasis, YaoBlocks.YaoArrayRegister
+using YaoToEinsum: pauli_basis_transformer, to_pauli_basis, to_pauli_basis_observable
 
 @testset "map density matrix" begin
     circuit = chain(5, [put(5, i=>H) for i=1:5]..., [control(5, 1, i=>Z) for i=2:5]..., repeat(5, H))
@@ -6,17 +7,29 @@ using Test, YaoToEinsum, YaoBlocks, YaoBlocks.BitBasis, YaoBlocks.YaoArrayRegist
     # first, we show the density matrix mode is just the abs2 of the vector mode
     initial_state = Dict([i => rand_state(1) for i=1:5])
     reg0 = join([initial_state[5-i+1] for i=1:5]...)
-    final_state = Dict([i => 1 for i=1:5])
+    final_state = Dict([i => rand_state(1) for i=1:5])
+    reg1 = join([final_state[5-i+1] for i=1:5]...)
     network = yao2einsum(circuit, mode=DensityMatrixMode(), initial_state=initial_state, final_state=final_state)
     res1 = contract(network)[]
-    res2 = abs2(product_state(bit"11111")' * (copy(reg0) |> circuit))
+    res2 = abs2(reg1' * (copy(reg0) |> circuit))
     @test res1 ≈ res2
+
+    # then, we check the density matrix input is correct
+    network_dm = yao2einsum(circuit, mode=DensityMatrixMode(), initial_state=Dict([k=>density_matrix(v) for (k, v) in initial_state]), final_state=Dict([k=>density_matrix(v) for (k, v) in final_state]))
+    res3 = contract(network_dm)[]
+    @test res3 ≈ res1
 
     # then, we show the density matrix mode supports observables
     @test_throws AssertionError yao2einsum(circuit, mode=DensityMatrixMode(), initial_state=initial_state, final_state=final_state, observable=put(5, 1=>Z))
-    network = yao2einsum(circuit, mode=DensityMatrixMode(), initial_state=initial_state, observable=put(5, 1=>Z))
+    network = yao2einsum(circuit, mode=DensityMatrixMode(), initial_state=initial_state, observable=put(5, 1=>X))
     res1 = contract(network)[]
-    res2 = expect(put(5, 1=>Z), copy(reg0) |> circuit)
+    res2 = expect(put(5, 1=>X), copy(reg0) |> circuit)
+    @test res1 ≈ res2
+
+    # then, we check the superop
+    network = yao2einsum(circuit, mode=DensityMatrixMode())
+    res1 = reshape(contract(network), 2^10, 2^10)
+    res2 = SuperOp(circuit).superop
     @test res1 ≈ res2
 
     # then, we check the channels
@@ -30,4 +43,35 @@ using Test, YaoToEinsum, YaoBlocks, YaoBlocks.BitBasis, YaoBlocks.YaoArrayRegist
     res1 = contract(network)[]
     res2 = expect(put(5, 1=>Z), density_matrix(reg0) |> circuit)
     @test res1 ≈ res2 atol=1e-8
+end
+
+@testset "pauli basis" begin
+    n = 2
+    U = pauli_basis_transformer(ComplexF64, n)
+    rho = DensityMatrix{2}(randn(ComplexF64, 2^n, 2^n))
+    op = SuperOp(randn(ComplexF64, 4^n, 4^n))
+    op2 = put(n, 1=>X)
+    rho1 = apply(to_pauli_basis(rho), to_pauli_basis(op))
+    rho2 = apply(rho, op)
+    res1 = sum(vec(rho1.state) .* vec(to_pauli_basis_observable(mat(op2))))
+    res2 = sum(vec(rho2.state) .* vec(mat(op2)))
+    @test res1 ≈ res2
+end
+
+@testset "pauli basis mode" begin
+    circuit = chain(5, [put(5, i=>H) for i=1:5]..., [control(5, 1, i=>Z) for i=2:5]..., repeat(5, H))
+    initial_state = Dict([i => rand_state(1) for i=1:5])
+    reg0 = join([initial_state[5-i+1] for i=1:5]...)
+    final_state = Dict([i => rand_state(1) for i=1:5])
+    reg1 = join([final_state[5-i+1] for i=1:5]...)
+    network0 = yao2einsum(circuit, mode=DensityMatrixMode(), initial_state=initial_state, final_state=final_state)
+    network = yao2einsum(circuit, mode=PauliBasisMode(), initial_state=initial_state, final_state=final_state)
+    res1 = contract(network)[]
+    res0 = contract(network0)[]
+    obs = kron(5, [i=>matblock(final_state[i].state * final_state[i].state') for i=1:5]...)
+    @test mat(obs) ≈ density_matrix(reg1).state atol=1e-8
+    res2 = expect(obs, density_matrix(reg0) |> circuit)
+    @show res0 res1 res2
+    @test res0 ≈ res2
+    @test res1 ≈ res2
 end

--- a/lib/YaoToEinsum/test/runtests.jl
+++ b/lib/YaoToEinsum/test/runtests.jl
@@ -3,3 +3,7 @@ using YaoToEinsum, Test
 @testset "circuitmap" begin
     include("circuitmap.jl")
 end
+
+@testset "densitymatrix" begin
+    include("densitymatrix.jl")
+end


### PR DESCRIPTION
## New features

Allow mapping a quantum simulation task to density matrice (super operator) basis.
The previous mode is named as `VectorMode`. The two new modes are: `DensityMatrixMode` and `PauliBasisMode`.

```julia
using Test, YaoToEinsum, YaoBlocks, YaoBlocks.YaoArrayRegister

# random circuit with noise channels
n = 3
c1 = quantum_channel(DepolarizingError(1, 0.1))     # DepolarizingChannel
circuit = chain(n, [put(n, i=>H) for i=1:n]..., [put(n, (1, i)=>control(2, 1, 2=>Z)) for i=2:n]..., put(n, 3=>c1), repeat(n, H))

# random noisy input and final state
initial_state = Dict([i => (density_matrix(rand_state(1)) |> YaoBlocks.DepolarizingChannel(1, 0.1)) for i=1:n])
final_state = Dict([i => (density_matrix(rand_state(1)) |> YaoBlocks.DepolarizingChannel(1, 0.1)) for i=1:n])

# observables
network0 = yao2einsum(circuit, mode=DensityMatrixMode(), initial_state=initial_state, observable=kron(n, 1=>X, 2=>Rx(0.3)))
network = yao2einsum(circuit, mode=PauliBasisMode(), initial_state=initial_state, observable=kron(n, 1=>X, 2=>Rx(0.3)))
res0 = contract(network0)[]
res1 = contract(network)[]
@test res0 ≈ res1
```