### PR TITLE
Fixed #575

### DIFF
--- a/lib/YaoSym/Project.toml
+++ b/lib/YaoSym/Project.toml
@@ -1,6 +1,6 @@
 name = "YaoSym"
 uuid = "3b27209a-d3d6-11e9-3c0f-41eb92b2cb9d"
-version = "0.6.11"
+version = "0.6.12"
 
 [deps]
 BitBasis = "50ba71b6-fa0f-514d-ae9a-0916efc90dcf"
@@ -14,7 +14,7 @@ YaoBlocks = "418bc28f-b43b-5e0b-a6e7-61bbc1a2c1df"
 [compat]
 BitBasis = "0.8, 0.9"
 LuxurySparse = "0.8"
-SymEngine = "0.11 - 0.13"
+SymEngine = "0.13"
 YaoArrayRegister = "0.9"
 YaoBlocks = "0.14"
 julia = "1"

--- a/lib/YaoSym/src/symengine/patch.jl
+++ b/lib/YaoSym/src/symengine/patch.jl
@@ -1,7 +1,3 @@
-function Base.iszero(x::Basic)
-    isempty(free_symbols(x)) && iszero(N(x))
-end
-
 SymEngine.free_symbols(syms::Union{Real,Complex}) = Basic[]
 SymEngine.free_symbols(syms::AbstractArray{T}) where {T<:Union{Real,Complex}} = Basic[]
 SymEngine.free_symbols(syms::AbstractArray{T}) where {T<:Union{Basic,SymEngine.BasicType}} =


### PR DESCRIPTION
This fixes the precompilation bug from #575 .

However, there is still some type piracy in https://github.com/QuantumBFS/Yao.jl/blob/master/lib/YaoSym/src/symengine/patch.jl. Namely, all of
https://github.com/QuantumBFS/Yao.jl/blob/27001cc35fa06793b3b31db793426c1645c71d46/lib/YaoSym/src/symengine/patch.jl#L5-L29

is defined on types and functions that don't belong to `Yao.jl`. Unfortunately, these methods are not defined in `SymEngine.jl`. For the additional `SymEngine.free_symbols` overloads I could see the SymEngine maintainers accepting PR's since these are IMHO fairly uncontroversial. But I am less sure about the definition of `isapprox`. 