### PR TITLE
Fixed O(n^2) precompilation work for islocs_inbounds and islocs_conflict

### DIFF
--- a/lib/YaoArrayRegister/Project.toml
+++ b/lib/YaoArrayRegister/Project.toml
@@ -1,6 +1,6 @@
 name = "YaoArrayRegister"
 uuid = "e600142f-9330-5003-8abb-0ebd767abc51"
-version = "0.9.13"
+version = "0.9.14"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/lib/YaoArrayRegister/src/error.jl
+++ b/lib/YaoArrayRegister/src/error.jl
@@ -27,6 +27,15 @@ end
 
 
 _sort(x::Vector; by = identity) = sort(x, by = by)
+# TupleTools.sort recurses on sub-tuples, generating O(N²) distinct _merge
+# specialisations for a length-N tuple.  collect+sort! compiles once per (N,T)
+# with O(N) LLVM instructions and zero recursive sub-specialisations.
+function _sort(x::NTuple{N,T}; by = identity) where {N,T}
+    v = collect(x)
+    sort!(v, by = by)
+    return return NTuple{N}(v)
+end
+# Heterogeneous Tuple (e.g. Tuple{Int, UnitRange{Int}}): always small in practice.
 _sort(x::Tuple; by = identity) = TupleTools.sort(x, by = by)
 
 # NOTE: this method assumes its input is not empty, it gets rid of errors
@@ -45,10 +54,7 @@ const AddressList{T} = Union{AddressVector{T},AddressNTuple{N,T} where N}
 Check if the input locations are inside given bounds `n`.
 """
 function islocs_inbounds(n::Int, locs::AddressList)
-    length(locs) == 0 && return true
-    locs = _sort(locs, by = x -> nonempty_minimum(x))
-    (minimum(first(locs)) > 0 && maximum(last(locs)) <= n) || return false
-    return true
+    all(loc -> nonempty_minimum(loc) > 0 && nonempty_maximum(loc) <= n, locs)
 end
 
 """
@@ -63,6 +69,18 @@ function islocs_conflict(locs::AddressList)
     end
     return false
 end
+
+function islocs_conflict(locs::NTuple{N,Int}) where {N}
+    # Use a BitVector keyed by location index; avoids any tuple recursion.
+    isempty(locs) && return false
+    seen = falses(maximum(locs))
+    for l in locs
+        @inbounds seen[l] && return true
+        @inbounds seen[l] = true
+    end
+    return false
+end
+
 
 function process_msgs(msgs...; default = "")
     msg = isempty(msgs) ? default : msgs[1]

--- a/lib/YaoArrayRegister/src/error.jl
+++ b/lib/YaoArrayRegister/src/error.jl
@@ -71,14 +71,7 @@ function islocs_conflict(locs::AddressList)
 end
 
 function islocs_conflict(locs::NTuple{N,T}) where {N, T<:Integer}
-    # Use a BitVector keyed by location index; avoids any tuple recursion.
-    isempty(locs) && return false
-    seen = falses(maximum(locs))
-    for l in locs
-        @inbounds seen[l] && return true
-        @inbounds seen[l] = true
-    end
-    return false
+    return !allunique(locs)
 end
 
 

--- a/lib/YaoArrayRegister/src/error.jl
+++ b/lib/YaoArrayRegister/src/error.jl
@@ -70,7 +70,7 @@ function islocs_conflict(locs::AddressList)
     return false
 end
 
-function islocs_conflict(locs::NTuple{N,Int}) where {N}
+function islocs_conflict(locs::NTuple{N,T}) where {N, T<:Integer}
     # Use a BitVector keyed by location index; avoids any tuple recursion.
     isempty(locs) && return false
     seen = falses(maximum(locs))


### PR DESCRIPTION
`@assert_locs_inbounds n locs "error message"` and `@assert_locs_safe` got enormously slow for large `locs` tuples. The culprit appeared to be that `TupleTools.sort` is a recursive merge sort on tuple types. `_merge(::NTuple{i}, ::NTuple{j}, ...)` requires a distinct LLVM specialisation for each (i,j) pair with `i+j ≤ N`, giving O(N²) new specialisations per first sort of length `N`.

This fixes these issues by not relying on TupleTools.sort for homogeneous tuples. Additionally,it speeds up `islocs_inbounds` from O(n log(n)) to O(n) on all input types and speeds up `islocs_conflict` from O(n log(n)) to O(n) for integer tuples.

For my concrete circuits (which were on several hundred qubits) this sped up things from running out of memory after half an hour to a few seconds to construct these circuits.