### PR TITLE
Document qudit constant gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ alt="Yao Logo" width="210"></img>
 [![][docs-dev-img]][docs-dev-url]
 [![Unitary Fund][unitary-fund-img]](http://unitary.fund)
 [![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor's%20Guide-blueviolet)](https://github.com/SciML/ColPrac)
+![Agent maintained](https://img.shields.io/badge/maintenance-agent%20maintained-blue)
 
 **Yao** Extensible, Efficient Quantum Algorithm Design for Humans.
 

--- a/docs/src/man/blocks.md
+++ b/docs/src/man/blocks.md
@@ -97,6 +97,14 @@ and it will also bind a Julia constant for the given matrix, so when you call `m
 @allocated mat(Rand)
 ```
 
+For a constant block acting on qudits, provide the local dimension with
+`nlevel`. This defines a constant gate acting on one qutrit:
+
+```@repl
+@const_gate RandQutrit = rand(ComplexF64, 3, 3) nlevel=3
+nlevel(RandQutrit)
+```
+
 If you want to use other data type like `ComplexF32`, you could directly call `Rand(ComplexF32)`, which will create a new instance with data type `ComplexF32`.
 
 ```@repl


### PR DESCRIPTION
The `@const_gate` macro supports `nlevel`, but the current block manual does not show how to use it. This adds a qutrit example and includes the required maintenance badge for Yao's first agent-created maintenance PR.

This preserves the useful current part of #477 without carrying forward its unrelated removal of documentation pages.

Validation:

- The exact expression matches the current macro parser and implementation in `const_gate_tools.jl`
- `git diff --check`
- Local execution was attempted, but the existing checkout lacks the `Reexport` dependency and new package installation is paused due host disk pressure; repository CI is required before merge

Supersedes #477.
