### PR TITLE
Document dispatch! behavior for shared blocks

### DIFF
--- a/lib/YaoBlocks/src/abstract_block.jl
+++ b/lib/YaoBlocks/src/abstract_block.jl
@@ -292,6 +292,14 @@ Dispatch parameters in collection to block tree `x`.
 !!! note
 
     it will try to dispatch the parameters in collection first.
+
+!!! warning
+
+    The operation mutates parameterized blocks in place. If the same block object
+    occurs more than once in the block tree, those occurrences share their final
+    parameter values and cannot receive distinct slices of `collection`. Construct
+    each occurrence independently (or use `deepcopy`) before calling `dispatch!`,
+    or use the non-mutating [`dispatch`](@ref), which rebuilds the block tree.
 """
 function dispatch!(f::Union{Function,Nothing}, x::AbstractBlock, it)
     dp = Dispatcher(it)


### PR DESCRIPTION
`dispatch!` walks every occurrence in a circuit and mutates its parameterized blocks. When repeated layers share the same underlying gate objects, later parameter slices overwrite the earlier values, while non-mutating `dispatch` rebuilds independent occurrences.

Document this aliasing constraint and the supported remedies: construct/deep-copy each occurrence before in-place dispatch, or use `dispatch`.

Closes #568.

Validation:
- reproduced the report on Yao 0.9.2: one layer matches, while two shared layers differ between `dispatch!` and `dispatch`
- verified independently deep-copied layers make `dispatch!` and `dispatch` agree (`norm == 0.0`)
- `git diff --check`
