### PR TITLE
Preserve empty ChainBlock in chsubblocks

### DIFF
--- a/lib/YaoBlocks/src/composite/chain.jl
+++ b/lib/YaoBlocks/src/composite/chain.jl
@@ -120,7 +120,7 @@ occupied_locs(c::ChainBlock) =
 
 chsubblocks(pb::ChainBlock{D}, blocks::Vector{<:AbstractBlock{D}}) where {D} =
     length(blocks) == 0 ? ChainBlock(pb.n, AbstractBlock{D}[]) : ChainBlock(pb.n, blocks)
-chsubblocks(pb::ChainBlock, it) = chain(it...)
+chsubblocks(pb::ChainBlock, it) = chain(pb.n, it)
 chsubblocks(x::ChainBlock, it::AbstractBlock) = chsubblocks(x, (it,))
 
 function mat(::Type{T}, c::ChainBlock{D}) where {T,D}

--- a/lib/YaoBlocks/src/composite/chain.jl
+++ b/lib/YaoBlocks/src/composite/chain.jl
@@ -120,7 +120,8 @@ occupied_locs(c::ChainBlock) =
 
 chsubblocks(pb::ChainBlock{D}, blocks::Vector{<:AbstractBlock{D}}) where {D} =
     length(blocks) == 0 ? ChainBlock(pb.n, AbstractBlock{D}[]) : ChainBlock(pb.n, blocks)
-chsubblocks(pb::ChainBlock, it) = chain(pb.n, it)
+chsubblocks(pb::ChainBlock{D}, it) where {D} =
+    isempty(it) ? ChainBlock(pb.n, AbstractBlock{D}[]) : chain(pb.n, it)
 chsubblocks(x::ChainBlock, it::AbstractBlock) = chsubblocks(x, (it,))
 
 function mat(::Type{T}, c::ChainBlock{D}) where {T,D}

--- a/lib/YaoBlocks/test/composite/chain.jl
+++ b/lib/YaoBlocks/test/composite/chain.jl
@@ -9,6 +9,7 @@ using LuxurySparse
     blks = [X, Y, Rx(0.3)]
     @test_throws QubitMismatchError chsubblocks(g, blks) |> subblocks |> collect == blks
     @test chsubblocks(chain(X, Y, Z), X for _ = 1:3) |> subblocks |> collect == [X, X, X]
+    @test chsubblocks(chain(3), Any[]) == chain(3)
 
     c1 = ChainBlock(put(5, 1 => X), put(5, 3 => Y))
     c2 = ChainBlock(put(5, 4 => X), put(5, 5 => Y))

--- a/lib/YaoBlocks/test/composite/chain.jl
+++ b/lib/YaoBlocks/test/composite/chain.jl
@@ -26,6 +26,17 @@ using LuxurySparse
     @test occupied_locs(chain(put(5, 2 => X), put(5, 3 => I2))) == (2,)
 end
 
+@testset "empty subblocks preserve qudit dimensions" begin
+    for D in (2, 3, 4), n in (0, 1, 2), it in (Any[], (), (x for x in Any[]))
+        original = chain(n; nlevel = D)
+        rebuilt = chsubblocks(original, it)
+        @test nlevel(rebuilt) == D
+        @test nqudits(rebuilt) == n
+        @test isempty(subblocks(rebuilt))
+        @test mat(rebuilt) == mat(original)
+    end
+end
+
 @testset "test chain" begin
     @test chain(kron(1 => X), control(2, 1 => X))(4) |> nqubits == 4
     @test chain(control(4, 2, 1 => X), kron(1 => X)) |> nqubits == 4


### PR DESCRIPTION
`chsubblocks(chain(3), Any[])` previously returned a curried `LegibleLambda` instead of a chain. Rebuilding empty generic inputs now preserves both the original register size and qudit level; nonempty inputs retain the existing parsing and size checks.

The empty fallback explicitly preserves `D`, so a qutrit chain remains a qutrit chain instead of silently becoming a qubit chain. Regression coverage exercises empty vectors, tuples and generators for levels 2, 3 and 4, including zero-size chains.

Validation: the regression reproduced 30 failures before the follow-up fix; all 188 assertions in `lib/YaoBlocks/test/composite/chain.jl` pass afterwards on Julia 1.12.4, including 108 new dimension and matrix checks. `git diff --check` passed. Remote CI for the revised head and independent critical review are recorded separately.
