### PR TITLE
Document canonicalizing nested circuit blocks

### DIFF
--- a/docs/src/performancetips.md
+++ b/docs/src/performancetips.md
@@ -37,6 +37,27 @@ julia> @time apply!(reg, chain([put(20, i=>X) for i=1:20]));
 
 Other gates accelerated by `repeat` include: `X`, `Y`, `Z`, `S`, `T`, `Sdag`, and `Tdag`.
 
+### Flatten nested circuit blocks
+
+Nested `put` and `chain` blocks can substantially increase compilation time for
+automatic differentiation. Use [`Optimise.canonicalize`](@ref) to flatten the
+circuit while preserving its operation:
+
+```julia
+julia> circuit = chain(4, put(4, (1, 2) => chain(2, put(1 => Rx(0.1)), put(2 => Ry(0.2)))));
+
+julia> flat = Optimise.canonicalize(circuit)
+nqubits: 4
+chain
+├─ put on (1)
+│  └─ rot(X, 0.1)
+└─ put on (2)
+   └─ rot(Y, 0.2)
+
+julia> mat(flat) ≈ mat(circuit)
+true
+```
+
 ### Diagonal matrix in `time_evole`
 
 ## Register storage


### PR DESCRIPTION
The nested `put => chain => put` performance report was answered with `Optimise.canonicalize`, but that method was difficult to discover outside the OpenQASM-specific documentation.

Add a performance-tip example showing how to flatten the nested structure and verify that its matrix is unchanged.

Validation:
- Executed the documented example against YaoBlocks and asserted matrix equivalence, two flattened blocks, and `PutBlock` output structure.
- `git diff --check`

Closes #569
