### PR TITLE
Add Aqua checks for three Yao components

### DIFF
--- a/lib/YaoAPI/Project.toml
+++ b/lib/YaoAPI/Project.toml
@@ -3,10 +3,13 @@ uuid = "0843a435-28de-4971-9e8b-a9641b2983a8"
 version = "0.4.9"
 
 [compat]
+Aqua = "0.8"
+Test = "1"
 julia = "1"
 
 [extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Aqua", "Test"]

--- a/lib/YaoAPI/test/runtests.jl
+++ b/lib/YaoAPI/test/runtests.jl
@@ -1,6 +1,9 @@
 using YaoAPI
 using Test
+using Aqua
 
 @testset "YaoAPI.jl" begin
     # Write your own tests here.
 end
+
+Aqua.test_all(YaoAPI)

--- a/lib/YaoPlots/Project.toml
+++ b/lib/YaoPlots/Project.toml
@@ -9,14 +9,17 @@ YaoArrayRegister = "e600142f-9330-5003-8abb-0ebd767abc51"
 YaoBlocks = "418bc28f-b43b-5e0b-a6e7-61bbc1a2c1df"
 
 [compat]
+Aqua = "0.8"
 LinearAlgebra = "1"
 Luxor = "4"
+Test = "1"
 YaoArrayRegister = "0.9"
 YaoBlocks = "0.14.1"
 julia = "1"
 
 [extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Aqua", "Test"]

--- a/lib/YaoPlots/test/runtests.jl
+++ b/lib/YaoPlots/test/runtests.jl
@@ -1,5 +1,8 @@
 using YaoPlots
 using Test
+using Aqua
+
+Aqua.test_all(YaoPlots)
 
 @testset "helperblock" begin
     include("helperblock.jl")

--- a/lib/YaoToEinsum/Project.toml
+++ b/lib/YaoToEinsum/Project.toml
@@ -16,15 +16,20 @@ LuxorGraphPlot = "1f49bdf2-22a7-4bc4-978b-948dc219fbbc"
 LuxorExt = "LuxorGraphPlot"
 
 [compat]
+Aqua = "0.8"
 JSON = "0.21, 1"
+LinearAlgebra = "1"
 LuxorGraphPlot = "0.5"
 OMEinsum = "0.9.1"
+SymEngine = "0.13"
+Test = "1"
 YaoBlocks = "0.14"
 julia = "1.9"
 
 [extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 SymEngine = "123dc426-2d89-5057-bbad-38513e3affd8"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "SymEngine", "LuxorGraphPlot"]
+test = ["Aqua", "Test", "SymEngine", "LuxorGraphPlot"]

--- a/lib/YaoToEinsum/test/runtests.jl
+++ b/lib/YaoToEinsum/test/runtests.jl
@@ -1,4 +1,7 @@
 using YaoToEinsum, Test
+using Aqua
+
+Aqua.test_all(YaoToEinsum)
 
 @testset "circuitmap" begin
     include("circuitmap.jl")


### PR DESCRIPTION
Add unsuppressed Aqua 0.8 checks to YaoAPI, YaoPlots, and YaoToEinsum through their normal test targets. The baseline found and fixes only missing standard-library/test compat metadata:

- YaoAPI: `Test`
- YaoPlots: `Test`
- YaoToEinsum: `LinearAlgebra`, `SymEngine`, and `Test`

Validation: `Aqua.test_all` passes without disabled checks for all three components; `Pkg.test("YaoAPI")` passes; and `git diff --check` passes.

This remains a bounded rollout. Unsuppressed baselines for the other CPU components found existing dispatch/API findings that need separate treatment: YaoArrayRegister has 8 ambiguities, YaoBlocks has 20 ambiguities, root Yao has 1 ambiguity, and YaoSym has 52 piracy findings. This PR does not suppress those checks or claim whole-monorepo Aqua coverage.
