### PR TITLE
Resolve FSim parameter dispatch ambiguity

### DIFF
--- a/src/EasyBuild/block_extension/FSimGate.jl
+++ b/src/EasyBuild/block_extension/FSimGate.jl
@@ -30,7 +30,7 @@ end
 
 YaoAPI.iparams_eltype(::FSimGate{T}) where T = T
 YaoAPI.getiparams(fs::FSimGate{T}) where T = (fs.theta, fs.phi)
-function YaoAPI.setiparams!(fs::FSimGate{T}, θ, ϕ) where T
+function YaoAPI.setiparams!(fs::FSimGate{T}, θ::Number, ϕ::Number) where T
     fs.theta = θ
     fs.phi = ϕ
     return fs

--- a/test/easybuild/block_extension/shortcuts.jl
+++ b/test/easybuild/block_extension/shortcuts.jl
@@ -6,6 +6,11 @@ using YaoPlots: vizcircuit, Luxor
 @testset "gates" begin
     @test isunitary(FSimGate(0.5, 0.6))
     fs = FSimGate(π/2, π/6)
+    fsparams = FSimGate(0.1, 0.2)
+    @test setiparams!(fsparams, 0.2, 0.3) === fsparams
+    @test getiparams(fsparams) == (0.2, 0.3)
+    @test setiparams!(fsparams, (0.4, 0.5)) === fsparams
+    @test getiparams(fsparams) == (0.4, 0.5)
     @test eval(parse_ex(dump_gate(fs), 1)) == fs
     cphase(nbits, i::Int, j::Int, θ::T) where T = control(nbits, i, j=>shift(θ))
     ic = ISWAP*cphase(2, 2, 1, π/6)


### PR DESCRIPTION
`FSimGate`'s untyped two-parameter `setiparams!` method overlaps YaoBlocks' generic numeric fallback, so Aqua reports a root-package ambiguity. Restrict the gate-specific intersection to its documented numeric parameters, preserving direct and tuple-based parameter updates while making dispatch unambiguous.

Validation:
- `Aqua.test_ambiguities(Yao)` passes without suppressions on Julia 1.12.4 with Aqua 0.8.16.
- The focused EasyBuild shortcut test file passes: 10 gate assertions and 1 visualization regression assertion.
- `git diff --check` passes.
